### PR TITLE
[Issue #21] GitHub Actionsへのテスト統合

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+name: Test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
+
+    - name: Set up Python
+      run: uv python install 3.12
+
+    - name: Install dependencies
+      run: uv sync
+
+    - name: Run tests with coverage
+      run: uv run pytest tests/ --cov=app --cov-report=xml --cov-report=term-missing
+
+    - name: Upload coverage reports
+      uses: codecov/codecov-action@v4
+      with:
+        file: ./coverage.xml
+        fail_ci_if_error: false
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ ACCOUNT_ID = $(shell aws sts get-caller-identity --query Account --output text)
 ECR_URL = $(ACCOUNT_ID).dkr.ecr.$(REGION).amazonaws.com
 IMAGE_URI = $(ECR_URL)/$(REPO_NAME):latest
 
-.PHONY: init plan apply destroy login build push deploy deploy-init setup run-local test test-cov update-endpoint get-runtime-info
+.PHONY: init plan apply destroy login build push deploy deploy-init setup run-local test test-cov ci-test update-endpoint get-runtime-info
 
 # --- Local Development ---
 setup:
@@ -29,6 +29,9 @@ test:
 
 test-cov:
 	uv run pytest tests/ --cov=app --cov-report=term-missing
+
+ci-test:
+	uv run pytest tests/ --cov=app --cov-report=xml --cov-report=term-missing
 
 # --- Terraform ---
 init:


### PR DESCRIPTION
## Summary
- GitHub ActionsのCIパイプラインにテスト実行を統合
- PRでテストが自動実行されるように設定

## 変更内容

### .github/workflows/test.yml
- mainブランチへのpush/PRでテスト自動実行
- uvを使用した依存関係インストール
- pytest + カバレッジレポート生成
- Codecovへのカバレッジアップロード（オプション）

### Makefile
- `ci-test`コマンドを追加（XML形式カバレッジレポート生成）

## Test plan
- [x] ワークフローファイルの構文が正しいことを確認
- [ ] PRマージ後、テストが自動実行されることを確認

## 注意事項
- Codecov連携を有効にする場合は、リポジトリのSecretsに`CODECOV_TOKEN`を設定してください

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)