### PR TITLE
Issue #38対応: Terraform変数化とセキュリティ強化

### DIFF
--- a/terraform/agentcore.tf
+++ b/terraform/agentcore.tf
@@ -15,7 +15,7 @@ resource "aws_bedrockagentcore_agent_runtime" "main" {
   }
 
   tags = {
-    Environment = "dev"
+    Environment = var.environment
     Project     = var.project_name
   }
 
@@ -28,5 +28,5 @@ resource "aws_bedrockagentcore_agent_runtime" "main" {
 # Agent Core Memory Resource
 resource "aws_bedrockagentcore_memory" "main" {
   name                  = "${var.project_name}_memory"
-  event_expiry_duration = 30
+  event_expiry_duration = var.memory_event_expiry_days
 }

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,7 +1,8 @@
 terraform {
   backend "s3" {
-    bucket = "kamoshika-terraform-agentcore-state-bucket"
-    key    = "terraform_agentcore/terraform/terraform.tfstate"
-    region = "ap-northeast-1"
+    bucket  = "kamoshika-terraform-agentcore-state-bucket"
+    key     = "terraform_agentcore/terraform/terraform.tfstate"
+    region  = "ap-northeast-1"
+    encrypt = true
   }
 }

--- a/terraform/ecr.tf
+++ b/terraform/ecr.tf
@@ -5,6 +5,11 @@ resource "aws_ecr_repository" "main" {
   image_scanning_configuration {
     scan_on_push = true
   }
+
+  tags = {
+    Environment = var.environment
+    Project     = var.project_name
+  }
 }
 
 # ECRイメージの最新ダイジェストを取得

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -15,8 +15,28 @@ resource "aws_iam_role" "agent_role" {
   })
 }
 
+# AgentCoreがBedrockモデルを呼び出すための最小権限ポリシー
+resource "aws_iam_policy" "agent_bedrock_access" {
+  name        = "${var.project_name}-agent-bedrock-policy"
+  description = "最小権限でAgentCoreがBedrockモデルを呼び出すためのポリシー"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "bedrock:InvokeModel",
+          "bedrock:InvokeModelWithResponseStream"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
 resource "aws_iam_role_policy_attachment" "agent_bedrock_access" {
-  policy_arn = "arn:aws:iam::aws:policy/AmazonBedrockFullAccess"
+  policy_arn = aws_iam_policy.agent_bedrock_access.arn
   role       = aws_iam_role.agent_role.name
 }
 

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -4,10 +4,10 @@ resource "aws_lambda_function" "invoker" {
   function_name = "${var.project_name}-invoker"
   role          = aws_iam_role.lambda_role.arn
   handler       = "invoker.lambda_handler"
-  runtime       = "python3.12"
+  runtime       = var.lambda_runtime
   filename      = "${path.module}/../lambda_function_payload.zip"
-  timeout       = 300
-  memory_size   = 512
+  timeout       = var.lambda_timeout_seconds
+  memory_size   = var.lambda_memory_mb
 
   source_code_hash = filebase64sha256("${path.module}/../lambda_function_payload.zip")
 
@@ -19,7 +19,7 @@ resource "aws_lambda_function" "invoker" {
   }
 
   tags = {
-    Environment = "dev"
+    Environment = var.environment
     Project     = var.project_name
     Purpose     = "AgentCore invoker"
   }
@@ -50,7 +50,7 @@ resource "aws_iam_role" "lambda_role" {
   })
 
   tags = {
-    Environment = "dev"
+    Environment = var.environment
     Project     = var.project_name
   }
 }
@@ -103,10 +103,10 @@ resource "aws_iam_role_policy_attachment" "lambda_policy_attach" {
 # CloudWatch Log Group for Lambda
 resource "aws_cloudwatch_log_group" "lambda_logs" {
   name              = "/aws/lambda/${var.project_name}-invoker"
-  retention_in_days = 7
+  retention_in_days = var.log_retention_days
 
   tags = {
-    Environment = "dev"
+    Environment = var.environment
     Project     = var.project_name
   }
 }

--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -3,7 +3,7 @@ resource "aws_s3_bucket" "trigger" {
   bucket = "${var.project_name}-trigger-bucket"
 
   tags = {
-    Environment = "dev"
+    Environment = var.environment
     Project     = var.project_name
     Purpose     = "AgentCore trigger bucket"
   }
@@ -28,6 +28,17 @@ resource "aws_s3_bucket_public_access_block" "trigger" {
   restrict_public_buckets = true
 }
 
+# S3バケットのサーバーサイド暗号化設定
+resource "aws_s3_bucket_server_side_encryption_configuration" "trigger" {
+  bucket = aws_s3_bucket.trigger.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
 # S3 bucket notification to trigger Lambda
 resource "aws_s3_bucket_notification" "trigger" {
   bucket = aws_s3_bucket.trigger.id
@@ -35,7 +46,7 @@ resource "aws_s3_bucket_notification" "trigger" {
   lambda_function {
     lambda_function_arn = aws_lambda_function.invoker.arn
     events              = ["s3:ObjectCreated:*"]
-    filter_suffix       = ".txt"
+    filter_suffix       = var.s3_trigger_suffix
   }
 
   depends_on = [aws_lambda_permission.s3]

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -9,3 +9,45 @@ variable "region" {
   type        = string
   default     = "ap-northeast-1"
 }
+
+variable "environment" {
+  description = "環境名（dev, stg, prdなど）"
+  type        = string
+  default     = "dev"
+}
+
+variable "lambda_runtime" {
+  description = "Lambda関数のランタイムバージョン"
+  type        = string
+  default     = "python3.12"
+}
+
+variable "lambda_timeout_seconds" {
+  description = "Lambda関数のタイムアウト時間（秒）"
+  type        = number
+  default     = 300
+}
+
+variable "lambda_memory_mb" {
+  description = "Lambda関数のメモリサイズ（MB）"
+  type        = number
+  default     = 512
+}
+
+variable "log_retention_days" {
+  description = "CloudWatch Logsの保持期間（日数）"
+  type        = number
+  default     = 7
+}
+
+variable "memory_event_expiry_days" {
+  description = "AgentCore Memoryのイベント保持期間（日数）"
+  type        = number
+  default     = 30
+}
+
+variable "s3_trigger_suffix" {
+  description = "S3バケットのトリガー対象ファイルの拡張子"
+  type        = string
+  default     = ".txt"
+}


### PR DESCRIPTION
## Summary
- ハードコード値を変数化（environment, lambda_runtime, lambda_timeout_seconds等）
- AmazonBedrockFullAccessを最小権限カスタムポリシーに置換
- S3サーバーサイド暗号化を追加
- Terraformステート暗号化を有効化

Fixes #38

## 変更ファイル
- `terraform/variables.tf` - 7つの新規変数追加
- `terraform/agentcore.tf` - 変数参照に変更
- `terraform/lambda.tf` - 変数参照に変更
- `terraform/s3.tf` - 変数参照 + 暗号化設定追加
- `terraform/ecr.tf` - タグ追加
- `terraform/iam.tf` - 最小権限カスタムポリシー追加
- `terraform/backend.tf` - encrypt = true追加

## Test plan
- [x] terraform plan成功を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)