### PR TITLE
Issue #39対応: Terraform locals導入とドキュメント統一

### DIFF
--- a/terraform/agentcore.tf
+++ b/terraform/agentcore.tf
@@ -1,7 +1,11 @@
-# Agent Core Runtime Resource
+# ==============================================================================
+# Bedrock AgentCore Runtime
+# ==============================================================================
+# エージェントのコンテナ実行環境を提供するリソース
+# ECRからコンテナイメージを取得し、Bedrockモデルを使用してエージェントを実行する
 # terraform_data.image_digest_triggerの変更でリソース更新がトリガーされる
 resource "aws_bedrockagentcore_agent_runtime" "main" {
-  agent_runtime_name = "${var.project_name}_runtime"
+  agent_runtime_name = local.runtime_name
   role_arn           = aws_iam_role.agent_role.arn
 
   agent_runtime_artifact {
@@ -14,10 +18,7 @@ resource "aws_bedrockagentcore_agent_runtime" "main" {
     network_mode = "PUBLIC"
   }
 
-  tags = {
-    Environment = var.environment
-    Project     = var.project_name
-  }
+  tags = local.common_tags
 
   # イメージダイジェストが変わったらリソースを更新
   lifecycle {
@@ -25,8 +26,14 @@ resource "aws_bedrockagentcore_agent_runtime" "main" {
   }
 }
 
-# Agent Core Memory Resource
+# ==============================================================================
+# Bedrock AgentCore Memory
+# ==============================================================================
+# エージェントの会話履歴やコンテキストを保持するメモリリソース
+# セッション管理とイベント保持期間を設定
 resource "aws_bedrockagentcore_memory" "main" {
-  name                  = "${var.project_name}_memory"
+  name                  = local.memory_name
   event_expiry_duration = var.memory_event_expiry_days
+
+  tags = local.common_tags
 }

--- a/terraform/ecr.tf
+++ b/terraform/ecr.tf
@@ -1,17 +1,22 @@
+# ==============================================================================
+# ECR Repository
+# ==============================================================================
+# エージェントのDockerイメージを格納するコンテナレジストリ
+# プッシュ時に自動でイメージスキャンを実行してセキュリティ脆弱性を検出
 resource "aws_ecr_repository" "main" {
-  name                 = "${var.project_name}-repo"
+  name                 = local.ecr_repository_name
   image_tag_mutability = "MUTABLE"
 
   image_scanning_configuration {
     scan_on_push = true
   }
 
-  tags = {
-    Environment = var.environment
-    Project     = var.project_name
-  }
+  tags = local.common_tags
 }
 
+# ==============================================================================
+# ECR Image Data Source
+# ==============================================================================
 # ECRイメージの最新ダイジェストを取得
 # :latestタグの中身が変わった場合にTerraformが変更を検知できるようにする
 data "aws_ecr_image" "latest" {
@@ -23,6 +28,9 @@ data "aws_ecr_image" "latest" {
   depends_on = [aws_ecr_repository.main]
 }
 
+# ==============================================================================
+# Image Digest Trigger
+# ==============================================================================
 # イメージダイジェストの変更を追跡するためのリソース
 # ダイジェストが変わるとAgentCore Runtimeの更新がトリガーされる
 resource "terraform_data" "image_digest_trigger" {

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -1,5 +1,10 @@
+# ==============================================================================
+# IAM Role for AgentCore
+# ==============================================================================
+# Bedrock AgentCoreが使用するIAMロール
+# Bedrockモデル呼び出し、ECRイメージ取得、S3アクセスの権限を付与
 resource "aws_iam_role" "agent_role" {
-  name = "${var.project_name}-agent-role"
+  name = local.agent_role_name
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
@@ -13,11 +18,17 @@ resource "aws_iam_role" "agent_role" {
       }
     ]
   })
+
+  tags = local.common_tags
 }
 
+# ==============================================================================
+# IAM Policy: Bedrock Model Access
+# ==============================================================================
 # AgentCoreがBedrockモデルを呼び出すための最小権限ポリシー
+# Claude Sonnetなどの基盤モデルを使用してエージェントを実行
 resource "aws_iam_policy" "agent_bedrock_access" {
-  name        = "${var.project_name}-agent-bedrock-policy"
+  name        = local.agent_bedrock_policy_name
   description = "最小権限でAgentCoreがBedrockモデルを呼び出すためのポリシー"
 
   policy = jsonencode({
@@ -33,6 +44,8 @@ resource "aws_iam_policy" "agent_bedrock_access" {
       }
     ]
   })
+
+  tags = local.common_tags
 }
 
 resource "aws_iam_role_policy_attachment" "agent_bedrock_access" {
@@ -40,9 +53,14 @@ resource "aws_iam_role_policy_attachment" "agent_bedrock_access" {
   role       = aws_iam_role.agent_role.name
 }
 
+# ==============================================================================
+# IAM Policy: ECR Access
+# ==============================================================================
+# AgentCoreがECRからコンテナイメージを取得するためのポリシー
+# エージェントの実行環境をECRから取得
 resource "aws_iam_policy" "agent_ecr_access" {
-  name        = "${var.project_name}-agent-ecr-policy"
-  description = "Allow Bedrock Agent to pull images from ECR"
+  name        = local.agent_ecr_policy_name
+  description = "AgentCoreがECRからイメージを取得するためのポリシー"
 
   policy = jsonencode({
     Version = "2012-10-17"
@@ -58,6 +76,8 @@ resource "aws_iam_policy" "agent_ecr_access" {
       }
     ]
   })
+
+  tags = local.common_tags
 }
 
 resource "aws_iam_role_policy_attachment" "agent_ecr_attach" {
@@ -65,10 +85,14 @@ resource "aws_iam_role_policy_attachment" "agent_ecr_attach" {
   role       = aws_iam_role.agent_role.name
 }
 
-# Policy to allow AgentCore to access S3 trigger bucket
+# ==============================================================================
+# IAM Policy: S3 Access
+# ==============================================================================
+# AgentCoreがS3トリガーバケットにアクセスするためのポリシー
+# S3に配置されたファイルを読み取ってエージェント処理を実行
 resource "aws_iam_policy" "agent_s3_access" {
-  name        = "${var.project_name}-agent-s3-policy"
-  description = "Allow AgentCore to read from S3 trigger bucket"
+  name        = local.agent_s3_policy_name
+  description = "AgentCoreがS3トリガーバケットから読み取るためのポリシー"
 
   policy = jsonencode({
     Version = "2012-10-17"
@@ -79,20 +103,21 @@ resource "aws_iam_policy" "agent_s3_access" {
           "s3:GetObject",
           "s3:HeadObject"
         ]
-        Resource = "arn:aws:s3:::${var.project_name}-trigger-bucket/*"
+        Resource = "arn:aws:s3:::${local.trigger_bucket_name}/*"
       },
       {
         Effect = "Allow"
         Action = [
           "s3:ListBucket"
         ]
-        Resource = "arn:aws:s3:::${var.project_name}-trigger-bucket"
+        Resource = "arn:aws:s3:::${local.trigger_bucket_name}"
       }
     ]
   })
+
+  tags = local.common_tags
 }
 
-# Attach S3 access policy to AgentCore role
 resource "aws_iam_role_policy_attachment" "agent_s3_attach" {
   policy_arn = aws_iam_policy.agent_s3_access.arn
   role       = aws_iam_role.agent_role.name

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -1,7 +1,11 @@
-# Lambda function to invoke AgentCore
-# Note: Use ../build_lambda.sh to create lambda_function_payload.zip with dependencies
+# ==============================================================================
+# Lambda Function: AgentCore Invoker
+# ==============================================================================
+# S3トリガーからAgentCoreを呼び出すLambda関数
+# S3にファイルがアップロードされるとこのLambdaが起動し、AgentCoreを実行
+# Note: ../build_lambda.sh でlambda_function_payload.zipを作成すること
 resource "aws_lambda_function" "invoker" {
-  function_name = "${var.project_name}-invoker"
+  function_name = local.lambda_function_name
   role          = aws_iam_role.lambda_role.arn
   handler       = "invoker.lambda_handler"
   runtime       = var.lambda_runtime
@@ -18,14 +22,15 @@ resource "aws_lambda_function" "invoker" {
     }
   }
 
-  tags = {
-    Environment = var.environment
-    Project     = var.project_name
-    Purpose     = "AgentCore invoker"
-  }
+  tags = merge(local.common_tags, {
+    Purpose = "AgentCore invoker"
+  })
 }
 
-# Lambda permission to allow S3 to invoke the function
+# ==============================================================================
+# Lambda Permission: S3 Trigger
+# ==============================================================================
+# S3バケットがLambda関数を呼び出すための権限
 resource "aws_lambda_permission" "s3" {
   statement_id  = "AllowS3Invoke"
   action        = "lambda:InvokeFunction"
@@ -34,9 +39,13 @@ resource "aws_lambda_permission" "s3" {
   source_arn    = aws_s3_bucket.trigger.arn
 }
 
-# IAM role for Lambda function
+# ==============================================================================
+# IAM Role for Lambda
+# ==============================================================================
+# Lambda関数が使用するIAMロール
+# S3、AgentCore、CloudWatch Logsへのアクセス権限を付与
 resource "aws_iam_role" "lambda_role" {
-  name = "${var.project_name}-lambda-role"
+  name = local.lambda_role_name
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
@@ -49,16 +58,16 @@ resource "aws_iam_role" "lambda_role" {
     }]
   })
 
-  tags = {
-    Environment = var.environment
-    Project     = var.project_name
-  }
+  tags = local.common_tags
 }
 
-# IAM policy for Lambda function
+# ==============================================================================
+# IAM Policy for Lambda
+# ==============================================================================
+# Lambda関数がS3、AgentCore、CloudWatch Logsにアクセスするためのポリシー
 resource "aws_iam_policy" "lambda_policy" {
-  name        = "${var.project_name}-lambda-policy"
-  description = "Policy for Lambda to access S3, AgentCore, and CloudWatch Logs"
+  name        = local.lambda_policy_name
+  description = "Lambda関数がS3、AgentCore、CloudWatch Logsにアクセスするためのポリシー"
 
   policy = jsonencode({
     Version = "2012-10-17"
@@ -88,25 +97,26 @@ resource "aws_iam_policy" "lambda_policy" {
           "logs:CreateLogStream",
           "logs:PutLogEvents"
         ]
-        Resource = "arn:aws:logs:${var.region}:*:log-group:/aws/lambda/${var.project_name}-invoker:*"
+        Resource = "arn:aws:logs:${var.region}:*:log-group:${local.lambda_log_group_name}:*"
       }
     ]
   })
+
+  tags = local.common_tags
 }
 
-# Attach the policy to the Lambda role
 resource "aws_iam_role_policy_attachment" "lambda_policy_attach" {
   policy_arn = aws_iam_policy.lambda_policy.arn
   role       = aws_iam_role.lambda_role.name
 }
 
+# ==============================================================================
 # CloudWatch Log Group for Lambda
+# ==============================================================================
+# Lambda関数のログを保存するCloudWatch Logsロググループ
 resource "aws_cloudwatch_log_group" "lambda_logs" {
-  name              = "/aws/lambda/${var.project_name}-invoker"
+  name              = local.lambda_log_group_name
   retention_in_days = var.log_retention_days
 
-  tags = {
-    Environment = var.environment
-    Project     = var.project_name
-  }
+  tags = local.common_tags
 }

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -1,0 +1,41 @@
+# ローカル変数定義
+# 共通タグやリソース命名パターンを定義
+
+locals {
+  # 全リソースに適用する共通タグ
+  common_tags = {
+    Project     = var.project_name
+    Environment = var.environment
+    ManagedBy   = "terraform"
+  }
+
+  # リソース命名パターン
+  # 命名規則: ${project_name}-{resource-type}-{purpose}
+  resource_prefix = var.project_name
+
+  # ECRリポジトリ名
+  ecr_repository_name = "${local.resource_prefix}-repo"
+
+  # IAMロール名
+  agent_role_name  = "${local.resource_prefix}-agent-role"
+  lambda_role_name = "${local.resource_prefix}-lambda-role"
+
+  # IAMポリシー名
+  agent_bedrock_policy_name = "${local.resource_prefix}-agent-bedrock-policy"
+  agent_ecr_policy_name     = "${local.resource_prefix}-agent-ecr-policy"
+  agent_s3_policy_name      = "${local.resource_prefix}-agent-s3-policy"
+  lambda_policy_name        = "${local.resource_prefix}-lambda-policy"
+
+  # AgentCore リソース名
+  runtime_name = "${local.resource_prefix}_runtime"
+  memory_name  = "${local.resource_prefix}_memory"
+
+  # Lambda関数名
+  lambda_function_name = "${local.resource_prefix}-invoker"
+
+  # S3バケット名
+  trigger_bucket_name = "${local.resource_prefix}-trigger-bucket"
+
+  # CloudWatch Logs
+  lambda_log_group_name = "/aws/lambda/${local.lambda_function_name}"
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,8 +1,8 @@
-# Outputs for local testing and reference
+# 出力値（ローカルテストや参照用）
 
 output "memory_id" {
   value       = aws_bedrockagentcore_memory.main.id
-  description = "AgentCore Memory ID for local testing"
+  description = "AgentCore Memory ID（ローカルテスト用）"
 }
 
 output "runtime_arn" {
@@ -17,7 +17,7 @@ output "runtime_id" {
 
 output "ecr_repository_url" {
   value       = aws_ecr_repository.main.repository_url
-  description = "ECR Repository URL"
+  description = "ECRリポジトリURL"
 }
 
 output "current_image_digest" {

--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -1,15 +1,21 @@
-# S3 Bucket for triggering AgentCore
+# ==============================================================================
+# S3 Bucket: Trigger Bucket
+# ==============================================================================
+# AgentCoreを起動するトリガーとなるS3バケット
+# ファイルがアップロードされるとLambda経由でAgentCoreが起動
 resource "aws_s3_bucket" "trigger" {
-  bucket = "${var.project_name}-trigger-bucket"
+  bucket = local.trigger_bucket_name
 
-  tags = {
-    Environment = var.environment
-    Project     = var.project_name
-    Purpose     = "AgentCore trigger bucket"
-  }
+  tags = merge(local.common_tags, {
+    Purpose = "AgentCore trigger bucket"
+  })
 }
 
-# Enable versioning for the trigger bucket
+# ==============================================================================
+# S3 Bucket Versioning
+# ==============================================================================
+# トリガーバケットのバージョニングを有効化
+# 誤削除や上書きからファイルを保護
 resource "aws_s3_bucket_versioning" "trigger" {
   bucket = aws_s3_bucket.trigger.id
 
@@ -18,7 +24,11 @@ resource "aws_s3_bucket_versioning" "trigger" {
   }
 }
 
-# Block public access to the trigger bucket
+# ==============================================================================
+# S3 Bucket Public Access Block
+# ==============================================================================
+# トリガーバケットへのパブリックアクセスをブロック
+# セキュリティベストプラクティスに従い、すべてのパブリックアクセスを遮断
 resource "aws_s3_bucket_public_access_block" "trigger" {
   bucket = aws_s3_bucket.trigger.id
 
@@ -28,7 +38,11 @@ resource "aws_s3_bucket_public_access_block" "trigger" {
   restrict_public_buckets = true
 }
 
-# S3バケットのサーバーサイド暗号化設定
+# ==============================================================================
+# S3 Bucket Server-Side Encryption
+# ==============================================================================
+# トリガーバケットのサーバーサイド暗号化設定
+# AES256でデータを自動的に暗号化
 resource "aws_s3_bucket_server_side_encryption_configuration" "trigger" {
   bucket = aws_s3_bucket.trigger.id
 
@@ -39,7 +53,11 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "trigger" {
   }
 }
 
-# S3 bucket notification to trigger Lambda
+# ==============================================================================
+# S3 Bucket Notification
+# ==============================================================================
+# S3バケットイベント通知設定
+# 指定した拡張子のファイルが作成されるとLambda関数を起動
 resource "aws_s3_bucket_notification" "trigger" {
   bucket = aws_s3_bucket.trigger.id
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,11 +1,11 @@
 variable "project_name" {
-  description = "Project name to be used for resource naming"
+  description = "プロジェクト名（リソース命名に使用）"
   type        = string
   default     = "agentcore"
 }
 
 variable "region" {
-  description = "AWS Region"
+  description = "AWSリージョン"
   type        = string
   default     = "ap-northeast-1"
 }


### PR DESCRIPTION
## Summary
- locals.tfを新規作成し共通タグとリソース命名パターンを標準化
- outputs.tf、variables.tfのdescriptionを日本語に統一
- 全リソースに日本語コメントを追加
- 各リソースのタグをlocal.common_tagsに統一

Fixes #39

## 変更ファイル
- `terraform/locals.tf` - 新規作成
- `terraform/variables.tf` - description日本語化
- `terraform/outputs.tf` - description日本語化
- `terraform/agentcore.tf` - locals適用、コメント追加
- `terraform/ecr.tf` - locals適用、コメント追加
- `terraform/iam.tf` - locals適用、コメント追加
- `terraform/lambda.tf` - locals適用、コメント追加
- `terraform/s3.tf` - locals適用、コメント追加

## Test plan
- [x] terraform fmt成功
- [x] terraform plan成功

## 依存関係
- PR #45 (Issue #38) が先にマージされる必要があります

🤖 Generated with [Claude Code](https://claude.com/claude-code)