### PR TITLE
[Issue #35] handler関数の責務分離

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,5 @@
 import logging
-import os
-
+from typing import Optional
 from .agent import create_agent
 from .memory import create_memory
 from .prompts import load_prompt
@@ -11,42 +10,129 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
+def parse_event(event: dict) -> dict:
+    """
+    イベントから必要な情報を抽出する。
+
+    Args:
+        event: AgentCoreから渡されるイベント辞書
+
+    Returns:
+        dict: 以下のキーを含む辞書
+            - session_id: セッションID
+            - actor_id: アクターID
+            - user_input: ユーザー入力テキスト
+            - s3_info: S3情報（存在する場合）またはNone
+    """
+    return {
+        "session_id": get_session_id(event),
+        "actor_id": get_actor_id(event),
+        "user_input": get_input_text(event),
+        "s3_info": event.get("s3_info")
+    }
+
+
+def initialize_memory(memory_id: str, session_id: str, actor_id: str) -> Optional[object]:
+    """
+    メモリを初期化する。
+
+    Args:
+        memory_id: メモリID（Noneまたは空文字列の場合はNoneを返す）
+        session_id: セッションID
+        actor_id: アクターID
+
+    Returns:
+        SessionManagerオブジェクト、またはNone（メモリIDがない場合やエラー時）
+    """
+    if not memory_id:
+        return None
+
+    try:
+        session_manager = create_memory(memory_id, session_id, actor_id)
+        logger.info(f"Memory enabled: memory_id={memory_id}, session_id={session_id}, actor_id={actor_id}")
+        return session_manager
+    except Exception as e:
+        logger.warning(f"Failed to initialize memory: {e}")
+        return None
+
+
+def build_s3_instruction(bucket: str, key: str) -> str:
+    """
+    S3ファイル処理用の命令文字列を生成する。
+
+    Args:
+        bucket: S3バケット名
+        key: S3オブジェクトキー
+
+    Returns:
+        S3ファイル処理用の命令文字列
+    """
+    return (
+        f"S3バケット '{bucket}' のファイル '{key}' を読み取り、内容を要約してください。\n"
+        f"use_awsツールを使用して以下のパラメータでファイルを取得してください:\n"
+        f"- service_name: 's3'\n"
+        f"- operation_name: 'get_object'\n"
+        f"- parameters: {{'Bucket': '{bucket}', 'Key': '{key}'}}\n"
+        f"- region: '{REGION}'"
+    )
+
+
+def run_agent(user_input: str, session_manager=None, system_prompt=None) -> str:
+    """
+    エージェントを実行する。
+
+    Args:
+        user_input: ユーザー入力テキスト
+        session_manager: セッションマネージャー（オプション）
+        system_prompt: システムプロンプト（オプション）
+
+    Returns:
+        エージェントの応答文字列（Noneの場合は空文字列ではなくNoneを返す）
+    """
+    agent = create_agent(session_manager=session_manager, system_prompt=system_prompt)
+    response = agent(user_input)
+    return response
+
+
 def handler(event, context):
     """
-    Entry point for Bedrock AgentCore Runtime.
-    Handles both regular invocations and S3 file processing.
+    Bedrock AgentCore Runtimeのエントリーポイント。
+
+    通常の呼び出しとS3ファイル処理の両方に対応する。
+
+    Args:
+        event: AgentCoreから渡されるイベント辞書
+        context: 実行コンテキスト
+
+    Returns:
+        dict: ステータスコードとレスポンスボディを含む辞書
     """
     logger.info("Received event: %s", event)
 
     try:
-        # Memory設定の読み取り（configモジュールから）
-        memory_id = get_memory_id()
-        session_id = get_session_id(event)
-        actor_id = get_actor_id(event)
+        # イベント解析
+        parsed = parse_event(event)
+        session_id = parsed["session_id"]
+        actor_id = parsed["actor_id"]
+        user_input = parsed["user_input"]
+        s3_info = parsed["s3_info"]
 
-        # session_managerの作成（memory_idがある場合のみ）
+        # メモリ初期化
+        memory_id = get_memory_id()
         session_manager = None
         if memory_id:
-            try:
-                session_manager = create_memory(memory_id, session_id, actor_id)
-                logger.info(f"Memory enabled: memory_id={memory_id}, session_id={session_id}, actor_id={actor_id}")
-            except Exception as e:
-                logger.warning(f"Failed to initialize memory: {e}")
+            session_manager = initialize_memory(memory_id, session_id, actor_id)
         else:
             logger.info("Memory disabled (no AGENTCORE_MEMORY_ID)")
 
-        # Check if this is an S3 file processing request
-        s3_info = event.get("s3_info")
+        # S3ファイル処理モード
         system_prompt = None
-        user_input = get_input_text(event)
-
         if s3_info:
-            # S3 file processing mode
             bucket = s3_info.get("bucket")
             key = s3_info.get("key")
             logger.info(f"S3 file processing request: s3://{bucket}/{key}")
 
-            # Load the summarization prompt with S3 context
+            # 要約プロンプトの読み込み
             try:
                 system_prompt = load_prompt("summarize", bucket=bucket, key=key, user_id=actor_id)
                 logger.info("Loaded summarization prompt")
@@ -55,23 +141,13 @@ def handler(event, context):
             except Exception as e:
                 logger.warning(f"Failed to load prompt: {e}")
 
-            # Create specific instruction for S3 file processing
-            user_input = (
-                f"S3バケット '{bucket}' のファイル '{key}' を読み取り、内容を要約してください。\n"
-                f"use_awsツールを使用して以下のパラメータでファイルを取得してください:\n"
-                f"- service_name: 's3'\n"
-                f"- operation_name: 'get_object'\n"
-                f"- parameters: {{'Bucket': '{bucket}', 'Key': '{key}'}}\n"
-                f"- region: '{REGION}'"
-            )
+            # S3用の命令文字列を生成
+            user_input = build_s3_instruction(bucket, key)
 
-        # Agentの作成
-        agent = create_agent(session_manager=session_manager, system_prompt=system_prompt)
+        # エージェント実行
+        response = run_agent(user_input, session_manager, system_prompt)
 
-        # Run the agent
-        response = agent(user_input)
-
-        # AgentResultオブジェクトを文字列に変換（JSON serializable化）
+        # レスポンスを文字列に変換（JSON serializable化）
         response_text = str(response) if response else ""
 
         return {"statusCode": 200, "body": {"response": response_text}}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,8 +3,8 @@ app/main.pyのテスト。
 
 handler関数の動作を検証する。エージェント実行は課金が発生するためモックを使用。
 """
-
-from unittest.mock import MagicMock, patch
+import pytest
+from unittest.mock import patch, MagicMock, ANY
 
 
 class TestHandler:
@@ -175,3 +175,297 @@ class TestHandler:
             assert result["statusCode"] == 200
             # Noneの場合は空文字列になる
             assert result["body"]["response"] == ""
+
+
+class TestParseEvent:
+    """parse_event関数のテストクラス。"""
+
+    def test_parse_event_with_basic_input(self, sample_event):
+        """
+        基本的な入力のイベントを正しく解析することを確認。
+
+        Args:
+            sample_event: 標準的なイベント
+        """
+        from app.main import parse_event
+
+        result = parse_event(sample_event)
+
+        # 返却値の構造を確認
+        assert "session_id" in result
+        assert "actor_id" in result
+        assert "user_input" in result
+        assert "s3_info" in result
+
+        # デフォルト値の確認
+        assert result["session_id"] is not None
+        assert result["actor_id"] is not None
+        assert result["user_input"] == "こんにちは"
+        assert result["s3_info"] is None
+
+    def test_parse_event_with_session_info(self, sample_event_with_session):
+        """
+        セッション情報を含むイベントを正しく解析することを確認。
+
+        Args:
+            sample_event_with_session: セッション情報付きイベント
+        """
+        from app.main import parse_event
+
+        result = parse_event(sample_event_with_session)
+
+        assert result["session_id"] == "test-session-001"
+        assert result["actor_id"] == "test-user-001"
+        assert result["user_input"] == "テストメッセージです"
+        assert result["s3_info"] is None
+
+    def test_parse_event_with_s3_info(self, sample_s3_event):
+        """
+        S3情報を含むイベントを正しく解析することを確認。
+
+        Args:
+            sample_s3_event: S3情報付きイベント
+        """
+        from app.main import parse_event
+
+        result = parse_event(sample_s3_event)
+
+        assert result["s3_info"] is not None
+        assert result["s3_info"]["bucket"] == "test-bucket"
+        assert result["s3_info"]["key"] == "test-folder/test-file.txt"
+
+    def test_parse_event_with_empty_input(self, empty_event):
+        """
+        空の入力のイベントでデフォルト値が使用されることを確認。
+
+        Args:
+            empty_event: 空の入力を持つイベント
+        """
+        from app.main import parse_event
+
+        result = parse_event(empty_event)
+
+        # デフォルト値 "Hello" が使用される
+        assert result["user_input"] == "Hello"
+
+    def test_parse_event_with_invalid_event(self, invalid_event):
+        """
+        不正な形式のイベントでもデフォルト値で動作することを確認。
+
+        Args:
+            invalid_event: inputキーがないイベント
+        """
+        from app.main import parse_event
+
+        result = parse_event(invalid_event)
+
+        # デフォルト値が使用される
+        assert result["user_input"] == "Hello"
+        assert result["session_id"] is not None
+        assert result["actor_id"] is not None
+
+
+class TestInitializeMemory:
+    """initialize_memory関数のテストクラス。"""
+
+    def test_initialize_memory_with_valid_params(self):
+        """
+        有効なパラメータでメモリ初期化が成功することを確認。
+
+        create_memory関数は実際のAWS呼び出しを行うため、モックを使用。
+        """
+        from app.main import initialize_memory
+
+        with patch("app.main.create_memory") as mock_create_memory:
+            mock_session_manager = MagicMock()
+            mock_create_memory.return_value = mock_session_manager
+
+            result = initialize_memory("test-memory-id", "test-session", "test-actor")
+
+            assert result == mock_session_manager
+            mock_create_memory.assert_called_once_with(
+                "test-memory-id", "test-session", "test-actor"
+            )
+
+    def test_initialize_memory_with_none_memory_id(self):
+        """
+        memory_idがNoneの場合、Noneが返されることを確認。
+        """
+        from app.main import initialize_memory
+
+        with patch("app.main.create_memory") as mock_create_memory:
+            result = initialize_memory(None, "test-session", "test-actor")
+
+            assert result is None
+            # create_memoryは呼ばれない
+            mock_create_memory.assert_not_called()
+
+    def test_initialize_memory_with_empty_memory_id(self):
+        """
+        memory_idが空文字列の場合、Noneが返されることを確認。
+        """
+        from app.main import initialize_memory
+
+        with patch("app.main.create_memory") as mock_create_memory:
+            result = initialize_memory("", "test-session", "test-actor")
+
+            assert result is None
+            mock_create_memory.assert_not_called()
+
+    def test_initialize_memory_handles_error(self):
+        """
+        create_memory呼び出し時のエラーが適切にハンドリングされることを確認。
+        """
+        from app.main import initialize_memory
+
+        with patch("app.main.create_memory") as mock_create_memory:
+            mock_create_memory.side_effect = Exception("Memory initialization failed")
+
+            result = initialize_memory("test-memory-id", "test-session", "test-actor")
+
+            # エラー時はNoneを返す
+            assert result is None
+
+
+class TestBuildS3Instruction:
+    """build_s3_instruction関数のテストクラス。"""
+
+    def test_build_s3_instruction_with_valid_params(self):
+        """
+        有効なバケットとキーでS3命令が正しく生成されることを確認。
+        """
+        from app.main import build_s3_instruction
+
+        result = build_s3_instruction("my-bucket", "path/to/file.txt")
+
+        # 命令文字列の内容を確認
+        assert "my-bucket" in result
+        assert "path/to/file.txt" in result
+        assert "use_aws" in result
+        assert "get_object" in result
+        assert "Bucket" in result
+        assert "Key" in result
+
+    def test_build_s3_instruction_with_special_characters(self):
+        """
+        特殊文字を含むバケット名とキーでも正しく命令が生成されることを確認。
+        """
+        from app.main import build_s3_instruction
+
+        result = build_s3_instruction(
+            "my-bucket-123", "folder-name/sub_folder/file-name_v2.txt"
+        )
+
+        assert "my-bucket-123" in result
+        assert "folder-name/sub_folder/file-name_v2.txt" in result
+
+    def test_build_s3_instruction_contains_region(self):
+        """
+        S3命令にREGION情報が含まれることを確認。
+        """
+        from app.main import build_s3_instruction
+
+        result = build_s3_instruction("test-bucket", "test-key")
+
+        # REGIONはap-northeast-1がデフォルト
+        assert "region" in result.lower()
+
+
+class TestRunAgent:
+    """run_agent関数のテストクラス。"""
+
+    def test_run_agent_with_basic_input(self):
+        """
+        基本的な入力でエージェントが実行されることを確認。
+
+        エージェント実行は課金が発生するため、モックを使用。
+        """
+        from app.main import run_agent
+
+        with patch("app.main.create_agent") as mock_create_agent:
+            mock_agent = MagicMock()
+            mock_agent.return_value = "エージェント応答"
+            mock_create_agent.return_value = mock_agent
+
+            result = run_agent("テスト入力", None, None)
+
+            assert result == "エージェント応答"
+            mock_create_agent.assert_called_once_with(
+                session_manager=None, system_prompt=None
+            )
+            mock_agent.assert_called_once_with("テスト入力")
+
+    def test_run_agent_with_session_manager(self):
+        """
+        session_managerを指定してエージェントが実行されることを確認。
+        """
+        from app.main import run_agent
+
+        with patch("app.main.create_agent") as mock_create_agent:
+            mock_agent = MagicMock()
+            mock_agent.return_value = "セッション管理応答"
+            mock_create_agent.return_value = mock_agent
+
+            mock_session_manager = MagicMock()
+            result = run_agent("入力", mock_session_manager, None)
+
+            assert result == "セッション管理応答"
+            mock_create_agent.assert_called_once_with(
+                session_manager=mock_session_manager, system_prompt=None
+            )
+
+    def test_run_agent_with_system_prompt(self):
+        """
+        system_promptを指定してエージェントが実行されることを確認。
+        """
+        from app.main import run_agent
+
+        with patch("app.main.create_agent") as mock_create_agent:
+            mock_agent = MagicMock()
+            mock_agent.return_value = "カスタムプロンプト応答"
+            mock_create_agent.return_value = mock_agent
+
+            result = run_agent("入力", None, "カスタムシステムプロンプト")
+
+            assert result == "カスタムプロンプト応答"
+            mock_create_agent.assert_called_once_with(
+                session_manager=None, system_prompt="カスタムシステムプロンプト"
+            )
+
+    def test_run_agent_with_all_params(self):
+        """
+        すべてのパラメータを指定してエージェントが実行されることを確認。
+        """
+        from app.main import run_agent
+
+        with patch("app.main.create_agent") as mock_create_agent:
+            mock_agent = MagicMock()
+            mock_agent.return_value = "完全な応答"
+            mock_create_agent.return_value = mock_agent
+
+            mock_session_manager = MagicMock()
+            result = run_agent(
+                "完全な入力", mock_session_manager, "完全なシステムプロンプト"
+            )
+
+            assert result == "完全な応答"
+            mock_create_agent.assert_called_once_with(
+                session_manager=mock_session_manager,
+                system_prompt="完全なシステムプロンプト",
+            )
+            mock_agent.assert_called_once_with("完全な入力")
+
+    def test_run_agent_handles_none_response(self):
+        """
+        エージェントがNoneを返した場合の処理を確認。
+        """
+        from app.main import run_agent
+
+        with patch("app.main.create_agent") as mock_create_agent:
+            mock_agent = MagicMock()
+            mock_agent.return_value = None
+            mock_create_agent.return_value = mock_agent
+
+            result = run_agent("入力", None, None)
+
+            assert result is None


### PR DESCRIPTION
## Summary
- `handler()`関数を責務ごとに分離してSRPに準拠
- イベント解析、メモリ初期化、S3命令生成、エージェント実行を別関数に抽出
- `handler()`を各関数の組み合わせに簡素化しテスタビリティを向上

## 変更内容
### 新規追加した関数
- `parse_event(event)`: イベントからsession_id, actor_id, user_input, s3_infoを抽出
- `initialize_memory(memory_id, session_id, actor_id)`: メモリ初期化
- `build_s3_instruction(bucket, key)`: S3命令文字列を生成
- `run_agent(user_input, session_manager, system_prompt)`: エージェント実行

### テスト
- 17件のテストケースを追加（全57件がPASS）
- カバレッジ: 91%

## Test plan
- [x] `make test` ですべてのテストが通ることを確認
- [x] 既存機能に影響がないことを確認

## Dependencies
- Requires #47 (Issue #34)

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)