### PR TITLE
[Issue #36] 型ヒントとドキュメント整備

### DIFF
--- a/app/agent.py
+++ b/app/agent.py
@@ -1,18 +1,23 @@
+from typing import Optional
 from strands import Agent
 from strands_tools import use_aws
+from bedrock_agentcore.memory.integrations.strands.session_manager import AgentCoreMemorySessionManager
 from .config import MODEL_ID
 
 
-def create_agent(session_manager=None, system_prompt=None):
+def create_agent(
+    session_manager: Optional[AgentCoreMemorySessionManager] = None,
+    system_prompt: Optional[str] = None
+) -> Agent:
     """
-    S3ファイル読み取り機能を持つエージェントを作成します。
+    S3ファイル読み取り機能を持つエージェントを作成する。
 
     Args:
-        session_manager: オプショナルなAgentCore Memoryセッションマネージャー
-        system_prompt: カスタムシステムプロンプト（デフォルト：汎用的なアシスタント）
+        session_manager: AgentCore Memoryセッションマネージャー（オプション）
+        system_prompt: カスタムシステムプロンプト（オプション、デフォルト：汎用的なアシスタント）
 
     Returns:
-        設定済みのAgentインスタンス
+        設定済みのStrandsエージェントインスタンス
     """
     default_prompt = "You are a helpful assistant. Answer concisely."
 

--- a/app/config.py
+++ b/app/config.py
@@ -3,7 +3,9 @@
 
 このモジュールは、環境変数から設定値を読み取り、デフォルト値を提供する。
 設定値は定数として定義され、実行時に動的に値を取得するヘルパー関数も提供する。
+また、アプリケーション全体のロギング設定も一元管理する。
 """
+import logging
 import os
 from typing import Optional
 
@@ -26,6 +28,31 @@ DEFAULT_ACTOR_ID = os.getenv("ACTOR_ID", "local-user")
 
 # デフォルト入力テキスト: エージェントへのデフォルト入力
 DEFAULT_INPUT_TEXT = os.getenv("DEFAULT_INPUT_TEXT", "Hello")
+
+
+# ========================================
+# ロギング設定
+# ========================================
+
+def setup_logging() -> None:
+    """
+    アプリケーション全体のロギング設定を初期化する。
+
+    この関数は、アプリケーション起動時に一度だけ呼び出される。
+    ログレベル、フォーマット、ハンドラーを統一的に設定する。
+
+    Returns:
+        None
+    """
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+        datefmt='%Y-%m-%d %H:%M:%S'
+    )
+
+
+# ロギング設定を初期化（モジュールインポート時に一度だけ実行）
+setup_logging()
 
 
 # ========================================

--- a/app/main.py
+++ b/app/main.py
@@ -1,16 +1,17 @@
 import logging
-from typing import Optional
+from typing import Any, Dict, Optional
+from strands import Agent
+from bedrock_agentcore.memory.integrations.strands.session_manager import AgentCoreMemorySessionManager
 from .agent import create_agent
 from .memory import create_memory
 from .prompts import load_prompt
 from .config import get_memory_id, get_session_id, get_actor_id, get_input_text, REGION
 
-# Configure logging
-logging.basicConfig(level=logging.INFO)
+# ロギング設定はconfig.pyで一元管理されている
 logger = logging.getLogger(__name__)
 
 
-def parse_event(event: dict) -> dict:
+def parse_event(event: Dict[str, Any]) -> Dict[str, Any]:
     """
     イベントから必要な情報を抽出する。
 
@@ -18,11 +19,11 @@ def parse_event(event: dict) -> dict:
         event: AgentCoreから渡されるイベント辞書
 
     Returns:
-        dict: 以下のキーを含む辞書
-            - session_id: セッションID
-            - actor_id: アクターID
-            - user_input: ユーザー入力テキスト
-            - s3_info: S3情報（存在する場合）またはNone
+        以下のキーを含む辞書:
+            - session_id (str): セッションID
+            - actor_id (str): アクターID
+            - user_input (str): ユーザー入力テキスト
+            - s3_info (Optional[Dict[str, str]]): S3情報（存在する場合）またはNone
     """
     return {
         "session_id": get_session_id(event),
@@ -32,7 +33,7 @@ def parse_event(event: dict) -> dict:
     }
 
 
-def initialize_memory(memory_id: str, session_id: str, actor_id: str) -> Optional[object]:
+def initialize_memory(memory_id: str, session_id: str, actor_id: str) -> Optional[AgentCoreMemorySessionManager]:
     """
     メモリを初期化する。
 
@@ -42,7 +43,10 @@ def initialize_memory(memory_id: str, session_id: str, actor_id: str) -> Optiona
         actor_id: アクターID
 
     Returns:
-        SessionManagerオブジェクト、またはNone（メモリIDがない場合やエラー時）
+        AgentCoreMemorySessionManagerオブジェクト、またはNone（メモリIDがない場合やエラー時）
+
+    Raises:
+        Exception: メモリ初期化時の例外（catchされてNoneが返される）
     """
     if not memory_id:
         return None
@@ -65,7 +69,7 @@ def build_s3_instruction(bucket: str, key: str) -> str:
         key: S3オブジェクトキー
 
     Returns:
-        S3ファイル処理用の命令文字列
+        S3ファイル処理用の命令文字列（エージェントへの指示を含む）
     """
     return (
         f"S3バケット '{bucket}' のファイル '{key}' を読み取り、内容を要約してください。\n"
@@ -77,7 +81,11 @@ def build_s3_instruction(bucket: str, key: str) -> str:
     )
 
 
-def run_agent(user_input: str, session_manager=None, system_prompt=None) -> str:
+def run_agent(
+    user_input: str,
+    session_manager: Optional[AgentCoreMemorySessionManager] = None,
+    system_prompt: Optional[str] = None
+) -> Any:
     """
     エージェントを実行する。
 
@@ -87,14 +95,14 @@ def run_agent(user_input: str, session_manager=None, system_prompt=None) -> str:
         system_prompt: システムプロンプト（オプション）
 
     Returns:
-        エージェントの応答文字列（Noneの場合は空文字列ではなくNoneを返す）
+        エージェントの応答（Strandsエージェントからの戻り値）
     """
     agent = create_agent(session_manager=session_manager, system_prompt=system_prompt)
     response = agent(user_input)
     return response
 
 
-def handler(event, context):
+def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     """
     Bedrock AgentCore Runtimeのエントリーポイント。
 
@@ -105,7 +113,12 @@ def handler(event, context):
         context: 実行コンテキスト
 
     Returns:
-        dict: ステータスコードとレスポンスボディを含む辞書
+        以下の形式の辞書:
+            - statusCode (int): HTTPステータスコード（200または500）
+            - body (Dict[str, str]): レスポンスボディ（responseまたはerrorキーを含む）
+
+    Raises:
+        Exception: エージェント実行時の例外（catchされて500エラーとして返される）
     """
     logger.info("Received event: %s", event)
 

--- a/app/memory.py
+++ b/app/memory.py
@@ -3,10 +3,21 @@ from bedrock_agentcore.memory.integrations.strands.session_manager import AgentC
 from .config import REGION
 
 
-def create_memory(mem_id: str, session_id: str, actor_id: str):
+def create_memory(mem_id: str, session_id: str, actor_id: str) -> AgentCoreMemorySessionManager:
     """
-    StrandsAgents の AgentCoreMemorySessionManagerを使って、
-    AgentCore の Memory を管理する
+    Strandsエージェント用のAgentCore Memoryセッションマネージャーを作成する。
+
+    Args:
+        mem_id: AgentCore MemoryのID
+        session_id: セッションID
+        actor_id: アクターID（ユーザーID）
+
+    Returns:
+        設定済みのAgentCoreMemorySessionManagerインスタンス
+
+    Raises:
+        ValueError: mem_id、session_id、actor_idのいずれかが空の場合
+        Exception: AgentCore Memory初期化時の例外
     """
     agentcore_memory_config = AgentCoreMemoryConfig(memory_id=mem_id, session_id=session_id, actor_id=actor_id)
 

--- a/app/server.py
+++ b/app/server.py
@@ -7,14 +7,13 @@ FastAPI HTTPサーバー - Bedrock AgentCore Runtime用。
 """
 
 import logging
-
+from typing import Dict, Any
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 
 from .main import handler
 
-# Configure logging
-logging.basicConfig(level=logging.INFO)
+# ロギング設定はconfig.pyで一元管理されている
 logger = logging.getLogger(__name__)
 
 # FastAPIアプリケーションの初期化
@@ -22,12 +21,12 @@ app = FastAPI(title="AgentCore Runtime Server", description="Bedrock AgentCore R
 
 
 @app.get("/ping")
-async def ping():
+async def ping() -> Dict[str, str]:
     """
     ヘルスチェックエンドポイント。
 
     Returns:
-        dict: ステータスメッセージを含む辞書
+        ステータスメッセージを含む辞書: {"status": "healthy"}
 
     Example:
         >>> GET /ping
@@ -38,7 +37,7 @@ async def ping():
 
 
 @app.post("/invocations")
-async def invocations(request: Request):
+async def invocations(request: Request) -> JSONResponse:
     """
     エージェント実行のメインエンドポイント。
 
@@ -49,10 +48,10 @@ async def invocations(request: Request):
         request: FastAPIリクエストオブジェクト
 
     Returns:
-        JSONResponse: エージェントの実行結果
+        エージェントの実行結果を含むJSONレスポンス
 
     Raises:
-        HTTPException: エージェント実行時のエラー
+        Exception: エージェント実行時のエラー（catchされて500エラーとして返される）
 
     Example:
         >>> POST /invocations
@@ -66,7 +65,7 @@ async def invocations(request: Request):
     """
     try:
         # リクエストボディをJSONとして取得
-        event = await request.json()
+        event: Dict[str, Any] = await request.json()
         logger.info(f"Invocation request received: {event}")
 
         # main.pyのhandler関数を呼び出し
@@ -95,12 +94,12 @@ async def invocations(request: Request):
 
 
 @app.get("/")
-async def root():
+async def root() -> Dict[str, Any]:
     """
     ルートエンドポイント。
 
     Returns:
-        dict: サーバー情報を含む辞書
+        サーバー情報を含む辞書
     """
     return {
         "service": "AgentCore Runtime Server",


### PR DESCRIPTION
## Summary
- すべての関数に完全な型ヒントを追加
- docstringをArgs/Returns/Raises形式に統一
- logging設定をconfig.pyに一元化

## 変更内容

### 型ヒントの完全化
- Optional型を明示的に使用
- 戻り値の型を具体的に指定（AgentCoreMemorySessionManager等）
- Dict[str, Any]などの詳細な型を使用

### docstringの標準化
```python
def function_name(arg1: str) -> str:
    """
    関数の説明。

    Args:
        arg1: 引数の説明

    Returns:
        戻り値の説明

    Raises:
        ErrorType: エラー条件
    """
```

### logging設定の一元化
- `app/config.py`に`setup_logging()`関数を追加
- 各モジュールから`logging.basicConfig()`を削除
- ログフォーマットを統一

## Test plan
- [x] `make test` ですべてのテストが通ることを確認

## Dependencies
- Requires #50 (Issue #35)

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)