### PR TITLE
Issue #60対応: AgentCore Memoryのログ・トレース配信設定

### DIFF
--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -38,4 +38,8 @@ locals {
 
   # CloudWatch Logs
   lambda_log_group_name = "/aws/lambda/${local.lambda_function_name}"
+
+  # Memory Observability
+  # vendedlogsプレフィックスはAWSのマネージドサービスログ用の標準パス
+  memory_log_group_name = "/aws/vendedlogs/bedrock-agentcore/${local.memory_name}"
 }

--- a/terraform/observability.tf
+++ b/terraform/observability.tf
@@ -1,0 +1,75 @@
+# ==============================================================================
+# AgentCore Memory Observability設定
+# ==============================================================================
+# MemoryリソースのログとトレースをCloudWatch LogsおよびX-Rayに配信する
+
+# ------------------------------------------------------------------------------
+# CloudWatch Log Group（Memory APPLICATION_LOGS用）
+# ------------------------------------------------------------------------------
+# Memoryの抽出（Extraction）・統合（Consolidation）プロセスのログを保存
+resource "aws_cloudwatch_log_group" "memory_logs" {
+  name              = local.memory_log_group_name
+  retention_in_days = var.log_retention_days
+
+  tags = local.common_tags
+}
+
+# ==============================================================================
+# APPLICATION_LOGS配信設定
+# ==============================================================================
+# Memoryの処理ログをCloudWatch Logsに配信
+
+# ログ配信ソース（APPLICATION_LOGS）
+resource "aws_cloudwatch_log_delivery_source" "memory_logs" {
+  name         = "${local.resource_prefix}-memory-logs-source"
+  log_type     = "APPLICATION_LOGS"
+  resource_arn = aws_bedrockagentcore_memory.main.arn
+
+  tags = local.common_tags
+}
+
+# ログ配信先（CloudWatch Logs）
+resource "aws_cloudwatch_log_delivery_destination" "memory_logs" {
+  name = "${local.resource_prefix}-memory-logs-destination"
+
+  delivery_destination_configuration {
+    destination_resource_arn = aws_cloudwatch_log_group.memory_logs.arn
+  }
+
+  tags = local.common_tags
+}
+
+# ログ配信の接続（ソース → 配信先）
+resource "aws_cloudwatch_log_delivery" "memory_logs" {
+  delivery_source_name     = aws_cloudwatch_log_delivery_source.memory_logs.name
+  delivery_destination_arn = aws_cloudwatch_log_delivery_destination.memory_logs.arn
+}
+
+# ==============================================================================
+# TRACES配信設定
+# ==============================================================================
+# MemoryのトレースデータをX-Rayに配信
+# CreateEvent, GetEvent, ListEvents, RetrieveMemoryRecordsなどのスパンデータ
+
+# トレース配信ソース（TRACES）
+resource "aws_cloudwatch_log_delivery_source" "memory_traces" {
+  name         = "${local.resource_prefix}-memory-traces-source"
+  log_type     = "TRACES"
+  resource_arn = aws_bedrockagentcore_memory.main.arn
+
+  tags = local.common_tags
+}
+
+# トレース配信先（X-Ray）
+resource "aws_cloudwatch_log_delivery_destination" "memory_traces" {
+  name                      = "${local.resource_prefix}-memory-traces-destination"
+  delivery_destination_type = "XRAY"
+
+  tags = local.common_tags
+}
+
+# トレース配信の接続（ソース → X-Ray）
+resource "aws_cloudwatch_log_delivery" "memory_traces" {
+  delivery_source_name     = aws_cloudwatch_log_delivery_source.memory_traces.name
+  delivery_destination_arn = aws_cloudwatch_log_delivery_destination.memory_traces.arn
+}


### PR DESCRIPTION
## Summary

- AgentCore MemoryのAPPLICATION_LOGSをCloudWatch Logsに配信
- AgentCore MemoryのTRACESをX-Rayに配信
- Terraform AWS providerのCloudWatch Log Delivery関連リソースを使用

## 変更内容

### 追加ファイル
- `terraform/observability.tf` - Memory Observability設定

### 変更ファイル
- `terraform/locals.tf` - メモリログ用ロググループ名を追加

### 作成されるリソース（7つ）
| リソース | 用途 |
|---------|------|
| `aws_cloudwatch_log_group.memory_logs` | APPLICATION_LOGS保存先 |
| `aws_cloudwatch_log_delivery_source.memory_logs` | ログ配信ソース |
| `aws_cloudwatch_log_delivery_source.memory_traces` | トレース配信ソース |
| `aws_cloudwatch_log_delivery_destination.memory_logs` | CloudWatch Logs配信先 |
| `aws_cloudwatch_log_delivery_destination.memory_traces` | X-Ray配信先 |
| `aws_cloudwatch_log_delivery.memory_logs` | ログ配信接続 |
| `aws_cloudwatch_log_delivery.memory_traces` | トレース配信接続 |

## Test plan

- [ ] `terraform plan`で変更内容を確認
- [ ] `terraform apply`でリソースを作成
- [ ] CloudWatch Logsでログが出力されることを確認
- [ ] X-Rayコンソールでトレースが表示されることを確認

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)