### PR TITLE
Issue #58対応: AgentCore Runtimeのバージョン管理機能の実装

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,21 +77,32 @@ make deploy-init             # 1. ECRリポジトリを作成
 
 **通常のデプロイメント**（コード変更時）：
 ```bash
-make deploy                  # 1. 新しいイメージをビルド＆プッシュ
-                            # 2. Terraformを適用（イメージダイジェストの変更を検知）
+make deploy                  # 1. 新しいイメージをビルド＆プッシュ（latestとgit commit hashタグ）
+                            # 2. Terraformを適用（UpdateAgentRuntime APIでin-place更新）
 ```
 
-**イメージ変更検知の仕組み**：
-- `data.aws_ecr_image.latest`でECRイメージのダイジェストを取得
-- `terraform_data.image_digest_trigger`でダイジェスト変更を追跡
-- ダイジェストが変わると`lifecycle.replace_triggered_by`でAgentCore Runtimeが再作成される
-- `make deploy`は必ず`push → apply`の順序で実行される（ダイジェスト取得のため）
+**イメージ変更検知とバージョン管理の仕組み**：
+- ECRイメージには`latest`タグとGit commit hashタグ（例: `abc1234`）の両方が付与される
+- `container_uri`の変更時は`UpdateAgentRuntime` APIでin-place更新される（destroy→createではない）
+- 更新のたびにAgentCore Runtimeの新しいバージョン（V1, V2, V3...）が自動作成される
+- バージョン履歴は保持され、ロールバック可能
+- DEFAULTエンドポイントは自動的に最新バージョンを指す
 
-**AgentCoreエンドポイント管理**：
+**AgentCoreエンドポイント・バージョン管理**：
 ```bash
-make update-endpoint         # DEFAULTエンドポイントを最新バージョンに更新
 make get-runtime-info        # Runtime情報とエンドポイント状態を表示
+make list-versions           # Runtime全バージョン一覧を表示
+make list-endpoints          # 全エンドポイント一覧を表示
+make update-endpoint         # DEFAULTエンドポイントを最新バージョンに更新
+make rollback VERSION=V1     # PRODエンドポイントを指定バージョンにロールバック
 ```
+
+**PRODエンドポイントの有効化**：
+本番環境で手動バージョン管理が必要な場合、Terraformで有効化できます：
+```bash
+make apply -- -var="enable_prod_endpoint=true"
+```
+PRODエンドポイントはDEFAULTと異なり、明示的に`make rollback`を実行しない限りバージョンが変更されません。
 
 ### AWS認証
 

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,16 @@ TF_DIR = terraform
 # AWS Account ID and ECR URL retrieval
 ACCOUNT_ID = $(shell aws sts get-caller-identity --query Account --output text)
 ECR_URL = $(ACCOUNT_ID).dkr.ecr.$(REGION).amazonaws.com
-IMAGE_URI = $(ECR_URL)/$(REPO_NAME):latest
 
-.PHONY: init plan apply destroy login build push deploy deploy-init setup test test-cov ci-test update-endpoint get-runtime-info lint format validate-tf clean help
+# Git commit hash for image tagging
+GIT_COMMIT = $(shell git rev-parse --short HEAD)
+GIT_COMMIT_FULL = $(shell git rev-parse HEAD)
+
+# Image URIs with version tags
+IMAGE_URI_LATEST = $(ECR_URL)/$(REPO_NAME):latest
+IMAGE_URI_VERSIONED = $(ECR_URL)/$(REPO_NAME):$(GIT_COMMIT)
+
+.PHONY: init plan apply destroy login build push deploy deploy-init setup test test-cov ci-test update-endpoint get-runtime-info list-versions list-endpoints rollback lint format validate-tf clean help
 
 # --- Help ---
 help:
@@ -42,8 +49,11 @@ help:
 	@echo "    deploy-init    - 初回デプロイ (ECR作成 → イメージプッシュ → Agent作成)"
 	@echo ""
 	@echo "  AgentCore:"
-	@echo "    update-endpoint  - DEFAULTエンドポイントを最新バージョンに更新"
 	@echo "    get-runtime-info - Runtime情報とエンドポイント状態を表示"
+	@echo "    list-versions    - Runtime全バージョン一覧を表示"
+	@echo "    list-endpoints   - 全エンドポイント一覧を表示"
+	@echo "    update-endpoint  - DEFAULTエンドポイントを最新バージョンに更新"
+	@echo "    rollback VERSION=V1 - PRODエンドポイントを指定バージョンにロールバック"
 
 # --- Local Development ---
 setup:
@@ -107,8 +117,11 @@ build:
 	fi
 
 push: login build
-	docker tag $(REPO_NAME):latest $(IMAGE_URI)
-	docker push $(IMAGE_URI)
+	docker tag $(REPO_NAME):latest $(IMAGE_URI_LATEST)
+	docker tag $(REPO_NAME):latest $(IMAGE_URI_VERSIONED)
+	docker push $(IMAGE_URI_LATEST)
+	docker push $(IMAGE_URI_VERSIONED)
+	@echo "Pushed images with tags: latest, $(GIT_COMMIT)"
 
 # --- Workflow ---
 # Push new image AND apply Terraform changes
@@ -157,3 +170,44 @@ get-runtime-info:
 	aws bedrock-agentcore-control list-agent-runtime-endpoints \
 		--agent-runtime-id $(RUNTIME_ID) \
 		--region $(REGION)
+
+# Runtimeの全バージョン一覧を表示
+list-versions:
+	@if [ -z "$(RUNTIME_ID)" ]; then \
+		echo "Error: Could not get Runtime ID. Run 'make apply' first."; \
+		exit 1; \
+	fi
+	@echo "=== AgentCore Runtime Versions ==="
+	aws bedrock-agentcore-control list-agent-runtime-versions \
+		--agent-runtime-id $(RUNTIME_ID) \
+		--region $(REGION)
+
+# 全エンドポイント一覧を表示
+list-endpoints:
+	@if [ -z "$(RUNTIME_ID)" ]; then \
+		echo "Error: Could not get Runtime ID. Run 'make apply' first."; \
+		exit 1; \
+	fi
+	@echo "=== AgentCore Runtime Endpoints ==="
+	aws bedrock-agentcore-control list-agent-runtime-endpoints \
+		--agent-runtime-id $(RUNTIME_ID) \
+		--region $(REGION)
+
+# PRODエンドポイントを指定バージョンにロールバック
+# 使用法: make rollback VERSION=V1
+rollback:
+	@if [ -z "$(RUNTIME_ID)" ]; then \
+		echo "Error: Could not get Runtime ID. Run 'make apply' first."; \
+		exit 1; \
+	fi
+	@if [ -z "$(VERSION)" ]; then \
+		echo "Error: VERSION is required. Usage: make rollback VERSION=V1"; \
+		exit 1; \
+	fi
+	@echo "Rolling back PROD endpoint to version $(VERSION)..."
+	aws bedrock-agentcore-control update-agent-runtime-endpoint \
+		--agent-runtime-id $(RUNTIME_ID) \
+		--endpoint-name PROD \
+		--agent-runtime-version $(VERSION) \
+		--region $(REGION)
+	@echo "Rollback initiated. Use 'make list-endpoints' to check status."

--- a/terraform/agentcore.tf
+++ b/terraform/agentcore.tf
@@ -3,13 +3,19 @@
 # ==============================================================================
 # エージェントのコンテナ実行環境を提供するリソース
 # ECRからコンテナイメージを取得し、Bedrockモデルを使用してエージェントを実行する
-# terraform_data.image_digest_triggerの変更でリソース更新がトリガーされる
+#
+# バージョン管理:
+# - container_uriの変更時はUpdateAgentRuntime APIでin-place更新される
+# - 更新のたびに新しいバージョン（V1, V2, V3...）が自動作成される
+# - バージョン履歴は保持され、ロールバック可能
+# - DEFAULTエンドポイントは自動的に最新バージョンを指す
 resource "aws_bedrockagentcore_agent_runtime" "main" {
   agent_runtime_name = local.runtime_name
   role_arn           = aws_iam_role.agent_role.arn
 
   agent_runtime_artifact {
     container_configuration {
+      # 常に:latestタグを参照するが、Makefileでgit commit hashタグも付与される
       container_uri = "${aws_ecr_repository.main.repository_url}:latest"
     }
   }
@@ -20,10 +26,9 @@ resource "aws_bedrockagentcore_agent_runtime" "main" {
 
   tags = local.common_tags
 
-  # イメージダイジェストが変わったらリソースを更新
-  lifecycle {
-    replace_triggered_by = [terraform_data.image_digest_trigger]
-  }
+  # 注意: lifecycle.replace_triggered_byは使用しない
+  # 理由: リソースをdestroy→createするとバージョン履歴が失われる
+  # 代わりにcontainer_uriの変更でin-place更新（UpdateAgentRuntime API）を使用
 }
 
 # ==============================================================================
@@ -49,4 +54,29 @@ resource "aws_bedrockagentcore_memory_strategy" "file_summary" {
   type        = "SEMANTIC"
   namespaces  = ["/file-summaries/{actorId}"]
   description = "S3ファイル要約を蓄積し、過去の要約を統合した出力を可能にするSemantic Memory Strategy"
+}
+
+# ==============================================================================
+# Bedrock AgentCore Runtime Endpoint - PROD
+# ==============================================================================
+# 本番環境用のカスタムエンドポイント
+# DEFAULTエンドポイントとは異なり、特定バージョンを明示的に指定可能
+#
+# 使い方:
+# - 初回作成時: 最新バージョン（V1）を指す
+# - ロールバック時: `make rollback VERSION=V1` で特定バージョンに切り替え
+# - バージョン確認: `make list-versions` でバージョン一覧を表示
+#
+# 注意: DEFAULTエンドポイントはAWSが自動作成・管理するため、
+# Terraformでは管理しない（常に最新バージョンを指す）
+resource "aws_bedrockagentcore_agent_runtime_endpoint" "prod" {
+  count = var.enable_prod_endpoint ? 1 : 0
+
+  agent_runtime_id = aws_bedrockagentcore_agent_runtime.main.agent_runtime_id
+  name             = "PROD"
+  description      = "Production endpoint - manually updated for controlled deployments"
+
+  # 注意: agent_runtime_versionは初回作成時のみ指定
+  # 以降のバージョン更新は `make rollback VERSION=VX` で実行
+  # Terraformでバージョンを管理すると、apply時に意図しないバージョン変更が発生する可能性がある
 }

--- a/terraform/ecr.tf
+++ b/terraform/ecr.tf
@@ -17,8 +17,8 @@ resource "aws_ecr_repository" "main" {
 # ==============================================================================
 # ECR Image Data Source
 # ==============================================================================
-# ECRイメージの最新ダイジェストを取得
-# :latestタグの中身が変わった場合にTerraformが変更を検知できるようにする
+# ECRイメージの最新ダイジェストを取得（参照用）
+# イメージのダイジェストをoutputに出力してデプロイ履歴を追跡可能にする
 data "aws_ecr_image" "latest" {
   repository_name = aws_ecr_repository.main.name
   image_tag       = "latest"
@@ -28,11 +28,6 @@ data "aws_ecr_image" "latest" {
   depends_on = [aws_ecr_repository.main]
 }
 
-# ==============================================================================
-# Image Digest Trigger
-# ==============================================================================
-# イメージダイジェストの変更を追跡するためのリソース
-# ダイジェストが変わるとAgentCore Runtimeの更新がトリガーされる
-resource "terraform_data" "image_digest_trigger" {
-  input = data.aws_ecr_image.latest.image_digest
-}
+# 注意: terraform_data.image_digest_triggerは削除済み
+# 理由: replace_triggered_byによるdestroy→createではなく
+# UpdateAgentRuntime APIによるin-place更新を使用するため

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -24,3 +24,8 @@ output "current_image_digest" {
   value       = data.aws_ecr_image.latest.image_digest
   description = "現在デプロイされているイメージのダイジェスト"
 }
+
+output "prod_endpoint_arn" {
+  value       = var.enable_prod_endpoint ? aws_bedrockagentcore_agent_runtime_endpoint.prod[0].agent_runtime_endpoint_arn : null
+  description = "PRODエンドポイントARN（enable_prod_endpoint=true時のみ）"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -51,3 +51,9 @@ variable "s3_trigger_suffix" {
   type        = string
   default     = ".txt"
 }
+
+variable "enable_prod_endpoint" {
+  description = "PRODエンドポイントを作成するかどうか（本番環境向けの手動バージョン管理用）"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
## Summary
- `replace_triggered_by`を削除し、UpdateAgentRuntime APIによるin-place更新に変更（バージョン履歴保持）
- ECRイメージにGit commit hashタグを追加（`latest`と`<commit-hash>`の両方）
- PRODエンドポイント作成機能を追加（`enable_prod_endpoint`変数で有効化）
- バージョン管理用Makeターゲット追加（`list-versions`, `list-endpoints`, `rollback`）

## Test plan
- [ ] `terraform validate`でTerraform設定が有効であることを確認済み
- [ ] `make push`でlatestとgit commit hashタグの両方がプッシュされることを確認
- [ ] `make deploy`でAgentCore Runtimeがin-place更新されることを確認
- [ ] `make list-versions`でバージョン一覧が表示されることを確認
- [ ] `enable_prod_endpoint=true`でPRODエンドポイントが作成されることを確認

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)