### PR TITLE
[Issue #63] ドキュメント構造の整理（README簡素化 + docsフォルダ作成）

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,70 +2,36 @@
 
 AWS Bedrock AgentCoreを使用して、コンテナ化されたAIエージェントをAWSにデプロイするためのプロジェクトです。
 
-## 概要
+## 技術スタック
 
-このプロジェクトは以下の技術スタックで構築されています：
-
-- **Strands Agents framework** - エージェント実装フレームワーク
-- **Bedrock AgentCore** - AWSマネージドエージェントホスティング
+- **Strands Agents framework** - エージェント実装
+- **Bedrock AgentCore** - マネージドエージェントホスティング
 - **Terraform** - インフラストラクチャ管理
 - **Docker + ECR** - コンテナイメージ管理
 - **uv** - Python依存関係管理
 
 ## 前提条件
 
-- AWS CLIがインストール・設定済み
-- Dockerがインストール済み
-- Terraformがインストール済み
+- AWS CLI（設定済み）
+- Docker
+- Terraform
 - Python 3.12+
-- uv（Python依存関係管理ツール）
-
-## プロジェクト構成
-
-```
-.
-├── app/
-│   ├── main.py          # エントリーポイント（handler関数）
-│   ├── agent.py         # エージェント設定（Claude Sonnet 4.5使用）
-│   ├── memory.py        # AgentCore Memory統合設定
-│   └── prompts/         # プロンプトテンプレート
-├── terraform/
-│   ├── agentcore.tf     # AgentCore RuntimeとMemoryリソース
-│   ├── ecr.tf           # ECRリポジトリ
-│   ├── iam.tf           # IAMロールとポリシー
-│   ├── lambda.tf        # Lambda関数（S3トリガー用）
-│   ├── s3.tf            # S3トリガーバケット
-│   ├── backend.tf       # Terraformステート管理
-│   └── variables.tf     # プロジェクト設定
-├── lambda/
-│   └── invoker.py       # S3イベントからAgentCoreを呼び出すLambda
-├── tests/               # テストコード
-├── .claude/agents/      # サブエージェント定義
-├── Dockerfile           # コンテナイメージ定義
-├── Makefile             # 便利なコマンド集
-└── pyproject.toml       # Python依存関係
-```
+- uv
 
 ## クイックスタート
-
-### 1. 初回デプロイ
 
 ```bash
 # 依存関係のインストール
 make setup
 
-# 初回デプロイ（ECR作成 → イメージビルド&プッシュ → AgentCore作成）
+# 初回デプロイ
 make deploy-init
-```
 
-### 2. コード変更後の更新デプロイ
-
-```bash
-# インフラ更新 + 新しいイメージをプッシュ
+# コード変更後の更新デプロイ
 make deploy
 ```
 
-## よく使うコマンド
+## コマンド一覧
 
 ### 開発
 
@@ -74,135 +40,60 @@ make deploy
 | `make setup` | 依存関係のインストール |
 | `make build` | Dockerイメージをビルド |
 | `make push` | イメージをビルド＆ECRにプッシュ |
-
-### インフラ
-
-| コマンド | 説明 |
-|---------|------|
-| `make init` | Terraformの初期化 |
-| `make plan` | インフラ変更のプレビュー |
-| `make apply` | インフラを適用 |
-| `make destroy` | すべてのリソースを削除 |
+| `make test` | テストを実行 |
+| `make test-cov` | カバレッジ付きでテスト |
 
 ### デプロイ
 
 | コマンド | 説明 |
 |---------|------|
-| `make deploy-init` | 初回デプロイ（ECR → イメージ → AgentCore） |
-| `make deploy` | 通常のデプロイ（インフラ更新 + イメージ更新） |
+| `make deploy-init` | 初回デプロイ |
+| `make deploy` | 通常のデプロイ |
+| `make plan` | インフラ変更のプレビュー |
+| `make apply` | インフラを適用 |
 
-### AgentCoreエンドポイント管理
-
-| コマンド | 説明 |
-|---------|------|
-| `make update-endpoint` | DEFAULTエンドポイントを最新バージョンに更新 |
-| `make get-runtime-info` | Runtime情報とエンドポイント一覧を表示 |
-
-### テスト
+### バージョン管理
 
 | コマンド | 説明 |
 |---------|------|
-| `make test` | 全テストを実行 |
-| `make test-cov` | カバレッジ付きでテストを実行 |
+| `make get-runtime-info` | Runtime情報を表示 |
+| `make list-versions` | バージョン一覧を表示 |
+| `make list-endpoints` | エンドポイント一覧を表示 |
+| `make update-endpoint` | DEFAULTエンドポイントを更新 |
+| `make rollback VERSION=V1` | 指定バージョンにロールバック |
 
 ## 設定
 
-デフォルト設定は`Makefile`で定義されています：
+| 項目 | デフォルト値 |
+|-----|-------------|
+| プロジェクト名 | `agentcore` |
+| リージョン | `ap-northeast-1` |
+| モデル | `jp.anthropic.claude-sonnet-4-5-20250929-v1:0` |
 
-- **プロジェクト名**: `agentcore`
-- **リージョン**: `ap-northeast-1`
-- **モデル**: `jp.anthropic.claude-sonnet-4-5-20250929-v1:0`（日本リージョン）
-
-設定を変更する場合は、`Makefile`の変数を編集するか、`terraform/variables.tf`を変更してください。
-
-## サブエージェント
-
-このプロジェクトでは、Claude Codeが使用する専門サブエージェントを定義しています。
-
-| エージェント | 専門領域 |
-|-------------|---------|
-| `terraform-specialist` | Terraform/AWSインフラ構築、IAM設計 |
-| `python-developer` | Pythonアプリケーション、Lambda関数実装 |
-| `strands-agent-developer` | Strands Agents、AgentCore統合 |
-| `integrator` | 統合検証、デプロイ確認 |
-| `test-specialist` | TDD、テスト実装、カバレッジ分析 |
-| `cloudwatch-investigator` | CloudWatchログ調査、エラー分析 |
-
-詳細は`.claude/agents/`ディレクトリと`CLAUDE.md`を参照してください。
-
-## アーキテクチャ
-
-```
-┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
-│   S3 Bucket     │────▶│     Lambda      │────▶│ AgentCore       │
-│  (トリガー)      │     │   (Invoker)     │     │  Runtime        │
-└─────────────────┘     └─────────────────┘     └────────┬────────┘
-                                                         │
-                                                         ▼
-                                               ┌─────────────────┐
-                                               │ Strands Agent   │
-                                               │ (Docker/ECR)    │
-                                               └────────┬────────┘
-                                                         │
-                                                         ▼
-                                               ┌─────────────────┐
-                                               │ AgentCore       │
-                                               │   Memory        │
-                                               └─────────────────┘
-```
-
-## 開発ガイドライン
-
-### Git/ブランチ戦略
-
-すべての作業は別ワークツリーで実施し、マージ前にプルリクエストを作成してください。
-
-```bash
-# 新しいワークツリーを作成
-git worktree add -b feature/issue-XX ../terraform_agentcore-issue-XX
-
-# 作業完了後、PRを作成
-gh pr create --title "Issue #XX対応" --body "変更内容"
-```
-
-### テスト方針
-
-- モックはなるべく使用せず、実際の環境でテストすることを優先
-- 課金が発生する外部サービスのみモックを許可
-
-詳細は`CLAUDE.md`を参照してください。
-
-## トラブルシューティング
-
-### AWS認証エラー
-
-```bash
-# AWS SSOで再認証
-aws login
-```
-
-### ECRログインエラー
-
-```bash
-make login
-```
-
-### AgentCore Runtimeの状態確認
-
-```bash
-make get-runtime-info
-```
-
-### エンドポイント更新が反映されない
-
-```bash
-make update-endpoint
-```
+設定変更は `Makefile` または `terraform/variables.tf` を編集してください。
 
 ## ドキュメント
 
-- `CLAUDE.md` - 開発ガイダンス、コーディング規約
-- `.claude/agents/` - サブエージェント定義
+| ドキュメント | 内容 |
+|-------------|------|
+| [デプロイメントガイド](docs/deployment.md) | デプロイ手順、イメージ更新の仕組み |
+| [バージョン管理ガイド](docs/version-management.md) | バージョン管理、ロールバック手順 |
+| [アーキテクチャ](docs/architecture.md) | システム構成、コンポーネント説明 |
+| [開発ガイド](docs/development.md) | 開発環境、テスト方針、Git戦略 |
+| [CLAUDE.md](CLAUDE.md) | Claude Code向け開発ガイダンス |
+
+## トラブルシューティング
+
+```bash
+# AWS認証エラー
+aws login
+
+# ECRログインエラー
+make login
+
+# Runtime状態確認
+make get-runtime-info
+```
 
 ## ライセンス
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,154 @@
+# アーキテクチャ
+
+このドキュメントでは、プロジェクトのアーキテクチャについて説明します。
+
+## システム構成図
+
+```
+┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
+│   S3 Bucket     │────▶│     Lambda      │────▶│ AgentCore       │
+│  (トリガー)      │     │   (Invoker)     │     │  Runtime        │
+└─────────────────┘     └─────────────────┘     └────────┬────────┘
+                                                         │
+                                                         ▼
+                                               ┌─────────────────┐
+                                               │ Strands Agent   │
+                                               │ (Docker/ECR)    │
+                                               └────────┬────────┘
+                                                         │
+                                                         ▼
+                                               ┌─────────────────┐
+                                               │ AgentCore       │
+                                               │   Memory        │
+                                               └─────────────────┘
+```
+
+## コンポーネント
+
+### AgentCore Runtime
+
+AWSが提供するマネージドエージェントホスティングサービス。
+
+- ECRからコンテナイメージを取得して実行
+- エンドポイントを通じてエージェントを呼び出し可能
+- バージョン管理機能を提供
+
+### Strands Agent（Docker/ECR）
+
+実際のエージェントロジックを実装したコンテナ。
+
+- `app/main.py` - AgentCoreから呼び出される `handler()` 関数
+- `app/agent.py` - Strands frameworkを使用したエージェント設定
+- `app/memory.py` - AgentCore Memory統合設定
+
+### AgentCore Memory
+
+エージェントの長期記憶を管理するサービス。
+
+- セッション間で情報を永続化
+- ログ・トレース配信設定でオブザーバビリティを確保
+
+### Lambda Invoker
+
+S3イベントをトリガーにAgentCoreを呼び出すLambda関数。
+
+- S3にファイルがアップロードされると起動
+- AgentCore Runtimeのエンドポイントを呼び出し
+
+## プロジェクト構成
+
+```
+.
+├── app/
+│   ├── main.py          # エントリーポイント（handler関数）
+│   ├── agent.py         # エージェント設定（Claude Sonnet 4.5使用）
+│   ├── memory.py        # AgentCore Memory統合設定
+│   └── prompts/         # プロンプトテンプレート
+├── terraform/
+│   ├── agentcore.tf     # AgentCore RuntimeとMemoryリソース
+│   ├── ecr.tf           # ECRリポジトリ
+│   ├── iam.tf           # IAMロールとポリシー
+│   ├── lambda.tf        # Lambda関数（S3トリガー用）
+│   ├── s3.tf            # S3トリガーバケット
+│   ├── backend.tf       # Terraformステート管理
+│   └── variables.tf     # プロジェクト設定
+├── lambda/
+│   └── invoker.py       # S3イベントからAgentCoreを呼び出すLambda
+├── tests/               # テストコード
+├── docs/                # ドキュメント
+├── .claude/agents/      # サブエージェント定義
+├── Dockerfile           # コンテナイメージ定義
+├── Makefile             # 便利なコマンド集
+└── pyproject.toml       # Python依存関係
+```
+
+## Terraformリソース
+
+### agentcore.tf
+
+- `aws_bedrockagentcore_agent_runtime` - AgentCore Runtime
+- `aws_bedrockagentcore_memory` - AgentCore Memory
+- エンドポイント設定（DEFAULT, PROD）
+
+### ecr.tf
+
+- `aws_ecr_repository` - Dockerイメージ用リポジトリ
+
+### iam.tf
+
+- AgentCore用のIAMロール
+- Bedrock、ECR、CloudWatch Logsへのアクセス権限
+
+### lambda.tf / s3.tf
+
+- S3トリガー用のLambda関数
+- トリガー用S3バケット
+
+## イベント構造
+
+AgentCoreはエージェントを以下の形式で呼び出します：
+
+```python
+{
+  "input": {
+    "text": "user input here"
+  }
+}
+```
+
+### セッション情報付きイベント
+
+```python
+{
+  "input": {
+    "text": "user input here"
+  },
+  "session_id": "session-123",
+  "memory_id": "memory-456",
+  "actor_id": "user-789"
+}
+```
+
+## Memory統合
+
+### 設定ファイル
+
+`app/memory.py` で AgentCore Memory との統合を設定：
+
+- Memory ID、Session ID、Actor IDを使用
+- Strands frameworkのsession_managerと連携
+
+### オブザーバビリティ
+
+AgentCore Memoryはログ・トレース配信設定をサポート：
+
+- CloudWatch Logsへのログ配信
+- トレース情報の収集
+
+詳細は `terraform/agentcore.tf` の Memory リソース定義を参照してください。
+
+## ネットワーク設定
+
+現在のネットワークモードは `PUBLIC` に設定されています（`agentcore.tf`）。
+
+プライベートネットワークが必要な場合は、VPC設定を追加してください。

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,120 @@
+# デプロイメントガイド
+
+このドキュメントでは、AgentCoreのデプロイメントワークフローについて説明します。
+
+## 前提条件
+
+デプロイを実行する前に、以下を確認してください：
+
+- AWS CLIがインストール・設定済み
+- Dockerがインストール済み
+- Terraformがインストール済み
+- AWS認証が有効（期限切れの場合は `aws login` を実行）
+
+## デプロイメントワークフロー
+
+### 初回デプロイ
+
+初めてプロジェクトをデプロイする場合は、以下のコマンドを実行します：
+
+```bash
+make deploy-init
+```
+
+このコマンドは以下の順序で実行されます：
+
+1. **ECRリポジトリの作成** - Dockerイメージを保存するリポジトリを作成
+2. **イメージのビルド＆プッシュ** - エージェントのDockerイメージをビルドしてECRにプッシュ
+3. **AgentCore RuntimeとMemoryの作成** - Terraformですべてのリソースをプロビジョニング
+
+### 通常のデプロイ（コード変更時）
+
+エージェントのコードを変更した後は、以下のコマンドでデプロイします：
+
+```bash
+make deploy
+```
+
+このコマンドは以下を実行します：
+
+1. **新しいイメージをビルド＆プッシュ**
+   - `latest` タグと Git commit hash タグ（例: `abc1234`）の両方を付与
+2. **Terraformを適用**
+   - `container_uri` の変更を検知
+   - `UpdateAgentRuntime` APIでin-place更新（destroy→createではない）
+
+## イメージ変更検知の仕組み
+
+### タグ付け戦略
+
+ECRにプッシュされるイメージには2つのタグが付与されます：
+
+| タグ | 用途 |
+|-----|------|
+| `latest` | 常に最新のイメージを指す |
+| Git commit hash | 特定のコミットに紐づくイメージを識別 |
+
+### In-Place更新
+
+Terraformは `container_uri` の変更を検知すると、AgentCore Runtimeをin-place更新します：
+
+- リソースの再作成（destroy→create）は発生しない
+- `UpdateAgentRuntime` APIが呼び出される
+- 新しいバージョン（V1, V2, V3...）が自動的に作成される
+- 既存のバージョン履歴は保持される
+
+## 個別コマンド
+
+### Dockerイメージ操作
+
+```bash
+# イメージをビルドのみ
+make build
+
+# ECRにログイン
+make login
+
+# ビルド＆プッシュ
+make push
+```
+
+### Terraform操作
+
+```bash
+# 初期化
+make init
+
+# 変更のプレビュー
+make plan
+
+# 適用
+make apply
+
+# 破棄
+make destroy
+```
+
+## トラブルシューティング
+
+### AWS認証エラー
+
+セッションが期限切れの場合：
+
+```bash
+aws login
+```
+
+### ECRログインエラー
+
+Docker認証が必要な場合：
+
+```bash
+make login
+```
+
+### デプロイが反映されない
+
+1. `make get-runtime-info` でRuntimeの状態を確認
+2. 必要に応じて `make update-endpoint` でエンドポイントを更新
+
+詳細なバージョン管理については [version-management.md](./version-management.md) を参照してください。

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,220 @@
+# 開発ガイド
+
+このドキュメントでは、開発環境のセットアップ、テスト方針、Git戦略について説明します。
+
+## 開発環境セットアップ
+
+### 前提条件
+
+- Python 3.12+
+- uv（Python依存関係管理ツール）
+- Docker
+- Terraform
+- AWS CLI
+
+### セットアップ
+
+```bash
+# 依存関係のインストール
+make setup
+```
+
+## テスト
+
+### コマンド
+
+```bash
+# 全テストを実行
+make test
+
+# カバレッジ付きでテストを実行
+make test-cov
+
+# 特定のテストファイルを実行
+uv run pytest tests/test_main.py -v
+
+# 特定のテスト関数を実行
+uv run pytest tests/test_main.py::TestHandler::test_handler_with_valid_input -v
+```
+
+### テストディレクトリ構造
+
+```
+tests/
+├── __init__.py              # テストパッケージ
+├── conftest.py              # 共通フィクスチャとpytest設定
+├── test_main.py             # app/main.pyのテスト
+├── test_agent.py            # app/agent.pyのテスト
+└── fixtures/                # テストデータとヘルパー
+    └── __init__.py
+```
+
+### テスト方針
+
+**重要原則**: モックはなるべく使用せず、実際の環境でテストすることを優先。
+
+**モックを使用してよい場合（最小限）**:
+- 課金が発生する外部サービス（EC2起動、S3への大量書き込みなど）
+- 制御できない外部依存（サードパーティAPIなど）
+- 時間がかかりすぎる処理（数分以上）
+
+**避けるべきモックの使用**:
+- 自分たちのコード内の関数をモック化する
+- boto3クライアントを安易にモック化する
+- テストの簡便さのためだけにモックを使用する
+
+### フィクスチャ
+
+`tests/conftest.py` に定義された共通フィクスチャ：
+
+| フィクスチャ | 用途 |
+|-------------|------|
+| `sample_event` | 標準的なAgentCoreイベント |
+| `sample_event_with_session` | セッション情報付きイベント |
+| `sample_s3_event` | S3ファイル処理用イベント |
+| `empty_event` / `invalid_event` | エラーハンドリングテスト用 |
+| `clean_env` | 環境変数をクリーンにする |
+| `set_memory_env` | Memory関連環境変数を設定 |
+
+## TDD（テスト駆動開発）
+
+### Red-Green-Refactorサイクル
+
+1. **Red** - テストを先に書く（失敗を確認）
+2. **Green** - 最小限の実装でテストを通す
+3. **Refactor** - コードを改善（テストが通ることを確認しながら）
+
+### ワークフロー例
+
+```bash
+# 1. テストを実装（Red）
+# tests/test_new_feature.py を作成
+
+# 2. テスト実行して失敗を確認
+make test
+
+# 3. 実装（Green）
+# app/new_feature.py を実装
+
+# 4. テスト実行して成功を確認
+make test
+
+# 5. リファクタリング（Refactor）
+# コードを改善
+
+# 6. カバレッジ確認
+make test-cov
+```
+
+## Git/ブランチ戦略
+
+すべての作業は別ワークツリーで実施し、マージ前にプルリクエストを作成してください。
+
+### ワークフロー
+
+#### 1. 別ワークツリーの作成
+
+```bash
+# Issue番号に基づいたブランチ名で別ワークツリー作成
+git worktree add -b feature/issue-XX-description ../terraform_agentcore-issue-XX
+cd ../terraform_agentcore-issue-XX
+```
+
+#### 2. 作業実施
+
+コードの実装・修正・テスト
+
+#### 3. 変更のコミット
+
+```bash
+git add .
+git status
+git diff --staged
+git commit -m "[Issue #XX] 変更内容の要約"
+```
+
+#### 4. プルリクエスト作成
+
+```bash
+git push -u origin feature/issue-XX-description
+gh pr create --title "Issue #XX対応: タイトル" --body "変更内容の説明"
+```
+
+#### 5. ワークツリーのクリーンアップ（マージ後）
+
+```bash
+cd ../terraform_agentcore
+git worktree remove ../terraform_agentcore-issue-XX
+git branch -d feature/issue-XX-description
+git pull origin main
+```
+
+## エージェント開発
+
+### ツールの追加
+
+`app/agent.py` を編集し、`tools=[]` パラメータにツールを追加します。
+
+```python
+from strands import Agent
+from strands_tools import calculator, web_search
+
+agent = Agent(
+    model="jp.anthropic.claude-sonnet-4-5-20250929-v1:0",
+    tools=[calculator, web_search],  # ツールを追加
+)
+```
+
+利用可能なツールは `strands-agents-tools` パッケージを参照してください。
+
+### Memory統合
+
+`app/memory.py` の `create_memory()` 関数を使用して Memory を統合できます：
+
+1. `main.py` でインポート
+2. eventからmemory_id、session_id、actor_idを抽出
+3. session_managerをエージェント設定に渡す
+
+## サブエージェント
+
+Claude Codeが使用する専門サブエージェント：
+
+| エージェント | 専門領域 |
+|-------------|---------|
+| `terraform-specialist` | Terraform/AWSインフラ構築、IAM設計 |
+| `python-developer` | Pythonアプリケーション、Lambda関数実装 |
+| `strands-agent-developer` | Strands Agents、AgentCore統合 |
+| `integrator` | 統合検証、デプロイ確認 |
+| `test-specialist` | TDD、テスト実装、カバレッジ分析 |
+| `cloudwatch-investigator` | CloudWatchログ調査、エラー分析 |
+
+詳細は `.claude/agents/` ディレクトリを参照してください。
+
+## コーディング規約
+
+### コメントとドキュメント
+
+- すべてのコメントとdocstringは日本語で記載
+- Python関数のdocstringは以下の形式：
+
+```python
+def function_name(arg1: str, arg2: int) -> str:
+    """
+    関数の簡潔な説明。
+
+    Args:
+        arg1: 引数1の説明
+        arg2: 引数2の説明
+
+    Returns:
+        戻り値の説明
+
+    Raises:
+        ErrorType: エラー発生条件の説明
+    """
+```
+
+### その他
+
+- 変数名や関数名は英語（Pythonの命名規則に従う）
+- インラインコメントも日本語で記載

--- a/docs/version-management.md
+++ b/docs/version-management.md
@@ -1,0 +1,133 @@
+# バージョン管理ガイド
+
+このドキュメントでは、AgentCore Runtimeのバージョン管理とエンドポイント操作について説明します。
+
+## 概要
+
+AgentCore Runtimeは、デプロイのたびに新しいバージョンが作成されます。これにより：
+
+- 過去のバージョン履歴が保持される
+- 問題発生時にロールバックが可能
+- 複数のエンドポイントで異なるバージョンを指定可能
+
+## エンドポイントの種類
+
+### DEFAULTエンドポイント
+
+- 自動的に最新バージョンを指す
+- `make deploy` 実行後、即座に新バージョンに切り替わる
+- 開発・テスト環境向け
+
+### PRODエンドポイント（オプション）
+
+- 明示的にバージョンを指定する必要がある
+- `make rollback` を実行しない限りバージョンは変更されない
+- 本番環境での安定運用向け
+
+#### PRODエンドポイントの有効化
+
+```bash
+make apply -- -var="enable_prod_endpoint=true"
+```
+
+## コマンド一覧
+
+### 情報取得
+
+```bash
+# Runtime情報とエンドポイント状態を表示
+make get-runtime-info
+
+# Runtime全バージョン一覧を表示
+make list-versions
+
+# 全エンドポイント一覧を表示
+make list-endpoints
+```
+
+### エンドポイント操作
+
+```bash
+# DEFAULTエンドポイントを最新バージョンに更新
+make update-endpoint
+
+# PRODエンドポイントを指定バージョンにロールバック
+make rollback VERSION=V1
+```
+
+## バージョン管理の仕組み
+
+### バージョン番号
+
+デプロイのたびに新しいバージョンが自動的に作成されます：
+
+```
+V1 → V2 → V3 → ...
+```
+
+### バージョン履歴の確認
+
+```bash
+make list-versions
+```
+
+出力例：
+
+```
+Version  Status   Created
+V1       ACTIVE   2024-01-01T00:00:00Z
+V2       ACTIVE   2024-01-02T00:00:00Z
+V3       ACTIVE   2024-01-03T00:00:00Z  ← 最新
+```
+
+## ロールバック手順
+
+### 1. 現在の状態を確認
+
+```bash
+make get-runtime-info
+make list-versions
+```
+
+### 2. ロールバック先のバージョンを決定
+
+過去のバージョン一覧から、戻したいバージョンを選択します。
+
+### 3. ロールバックを実行
+
+```bash
+make rollback VERSION=V1
+```
+
+### 4. 動作確認
+
+ロールバック後、エージェントが正常に動作することを確認してください。
+
+## ベストプラクティス
+
+### 開発環境
+
+- DEFAULTエンドポイントを使用
+- `make deploy` で自動的に最新バージョンに更新
+
+### 本番環境
+
+1. PRODエンドポイントを有効化
+2. 開発環境でテスト完了後、明示的に `make rollback` でバージョンを更新
+3. 問題発生時は即座に前バージョンにロールバック
+
+### リリースフロー例
+
+```bash
+# 1. 開発環境にデプロイ（DEFAULTエンドポイント）
+make deploy
+
+# 2. 新バージョンを確認
+make list-versions
+
+# 3. テスト完了後、PRODエンドポイントを更新
+make rollback VERSION=V5
+
+# 4. 問題発生時はロールバック
+make rollback VERSION=V4
+```


### PR DESCRIPTION
## Summary

- docsフォルダを作成し、詳細ドキュメントを分離
- README.mdを簡素化（約210行 → 約100行）
- 各ドキュメントからの相互リンクを追加

## 作成したドキュメント

| ファイル | 内容 |
|---------|------|
| `docs/deployment.md` | デプロイメントワークフロー、イメージ変更検知の仕組み |
| `docs/version-management.md` | バージョン管理、ロールバック手順、エンドポイント操作 |
| `docs/architecture.md` | システム構成図、コンポーネント説明、プロジェクト構成 |
| `docs/development.md` | 開発環境セットアップ、テスト方針、Git戦略、コーディング規約 |

## README.mdの変更

以下を簡素化：
- プロジェクト構成の削除（→ architecture.md へ）
- アーキテクチャ図の削除（→ architecture.md へ）
- 開発ガイドラインの削除（→ development.md へ）
- トラブルシューティングの簡素化

以下を追加：
- バージョン管理コマンド（list-versions, list-endpoints, rollback）
- docsフォルダへのリンク一覧

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)