### PR TITLE
Issue #65: AgentCore Runtimeのログ出力とトレース有効化

### DIFF
--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -42,4 +42,10 @@ locals {
   # Memory Observability
   # vendedlogsプレフィックスはAWSのマネージドサービスログ用の標準パス
   memory_log_group_name = "/aws/vendedlogs/bedrock-agentcore/${local.memory_name}"
+
+  # Runtime Observability
+  # APPLICATION_LOGS: エージェントの標準出力・エラーログ
+  # USAGE_LOGS: セッションレベルのCPU/メモリ使用量ログ
+  runtime_app_log_group_name   = "/aws/vendedlogs/bedrock-agentcore/runtime/${local.runtime_name}/APPLICATION_LOGS"
+  runtime_usage_log_group_name = "/aws/vendedlogs/bedrock-agentcore/runtime/${local.runtime_name}/USAGE_LOGS"
 }

--- a/terraform/observability.tf
+++ b/terraform/observability.tf
@@ -1,4 +1,11 @@
 # ==============================================================================
+# AgentCore Observability設定
+# ==============================================================================
+# Memory・RuntimeリソースのログとトレースをCloudWatch LogsおよびX-Rayに配信する
+#
+# 参考: https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/observability-configure.html
+
+# ==============================================================================
 # AgentCore Memory Observability設定
 # ==============================================================================
 # MemoryリソースのログとトレースをCloudWatch LogsおよびX-Rayに配信する
@@ -72,4 +79,119 @@ resource "aws_cloudwatch_log_delivery_destination" "memory_traces" {
 resource "aws_cloudwatch_log_delivery" "memory_traces" {
   delivery_source_name     = aws_cloudwatch_log_delivery_source.memory_traces.name
   delivery_destination_arn = aws_cloudwatch_log_delivery_destination.memory_traces.arn
+}
+
+# ==============================================================================
+# AgentCore Runtime Observability設定
+# ==============================================================================
+# RuntimeリソースのログとトレースをCloudWatch LogsおよびX-Rayに配信する
+#
+# ログタイプ:
+# - APPLICATION_LOGS: エージェントの標準出力・エラーログ（デバッグ、エラー調査用）
+# - USAGE_LOGS: セッションレベルのCPU/メモリ使用量ログ（コスト分析、リソース監視用）
+# - TRACES: InvokeAgentRuntimeなどのスパンデータ（パフォーマンス分析、リクエストトレース用）
+
+# ------------------------------------------------------------------------------
+# CloudWatch Log Group（Runtime APPLICATION_LOGS用）
+# ------------------------------------------------------------------------------
+# エージェントの標準出力・エラーログを保存
+resource "aws_cloudwatch_log_group" "runtime_app_logs" {
+  name              = local.runtime_app_log_group_name
+  retention_in_days = var.log_retention_days
+
+  tags = local.common_tags
+}
+
+# ログ配信ソース（APPLICATION_LOGS）
+resource "aws_cloudwatch_log_delivery_source" "runtime_app_logs" {
+  name         = "${local.resource_prefix}-runtime-app-logs-source"
+  log_type     = "APPLICATION_LOGS"
+  resource_arn = aws_bedrockagentcore_agent_runtime.main.agent_runtime_arn
+
+  tags = local.common_tags
+}
+
+# ログ配信先（CloudWatch Logs）
+resource "aws_cloudwatch_log_delivery_destination" "runtime_app_logs" {
+  name = "${local.resource_prefix}-runtime-app-logs-destination"
+
+  delivery_destination_configuration {
+    destination_resource_arn = aws_cloudwatch_log_group.runtime_app_logs.arn
+  }
+
+  tags = local.common_tags
+}
+
+# ログ配信の接続（ソース → 配信先）
+resource "aws_cloudwatch_log_delivery" "runtime_app_logs" {
+  delivery_source_name     = aws_cloudwatch_log_delivery_source.runtime_app_logs.name
+  delivery_destination_arn = aws_cloudwatch_log_delivery_destination.runtime_app_logs.arn
+}
+
+# ------------------------------------------------------------------------------
+# CloudWatch Log Group（Runtime USAGE_LOGS用）
+# ------------------------------------------------------------------------------
+# セッションレベルのCPU/メモリ使用量ログを保存
+resource "aws_cloudwatch_log_group" "runtime_usage_logs" {
+  name              = local.runtime_usage_log_group_name
+  retention_in_days = var.log_retention_days
+
+  tags = local.common_tags
+}
+
+# ログ配信ソース（USAGE_LOGS）
+resource "aws_cloudwatch_log_delivery_source" "runtime_usage_logs" {
+  name         = "${local.resource_prefix}-runtime-usage-logs-source"
+  log_type     = "USAGE_LOGS"
+  resource_arn = aws_bedrockagentcore_agent_runtime.main.agent_runtime_arn
+
+  tags = local.common_tags
+}
+
+# ログ配信先（CloudWatch Logs）
+resource "aws_cloudwatch_log_delivery_destination" "runtime_usage_logs" {
+  name = "${local.resource_prefix}-runtime-usage-logs-destination"
+
+  delivery_destination_configuration {
+    destination_resource_arn = aws_cloudwatch_log_group.runtime_usage_logs.arn
+  }
+
+  tags = local.common_tags
+}
+
+# ログ配信の接続（ソース → 配信先）
+resource "aws_cloudwatch_log_delivery" "runtime_usage_logs" {
+  delivery_source_name     = aws_cloudwatch_log_delivery_source.runtime_usage_logs.name
+  delivery_destination_arn = aws_cloudwatch_log_delivery_destination.runtime_usage_logs.arn
+}
+
+# ------------------------------------------------------------------------------
+# Runtime TRACES配信設定
+# ------------------------------------------------------------------------------
+# RuntimeのトレースデータをX-Rayに配信
+# InvokeAgentRuntimeなどのスパンデータ
+
+# トレース配信ソース（TRACES）
+resource "aws_cloudwatch_log_delivery_source" "runtime_traces" {
+  name         = "${local.resource_prefix}-runtime-traces-source"
+  log_type     = "TRACES"
+  resource_arn = aws_bedrockagentcore_agent_runtime.main.agent_runtime_arn
+
+  tags = local.common_tags
+}
+
+# トレース配信先（X-Ray）
+# MemoryとRuntimeで同じX-Ray配信先を共有可能だが、
+# 管理の明確化のため個別に定義
+resource "aws_cloudwatch_log_delivery_destination" "runtime_traces" {
+  name                      = "${local.resource_prefix}-runtime-traces-destination"
+  delivery_destination_type = "XRAY"
+
+  tags = local.common_tags
+}
+
+# トレース配信の接続（ソース → X-Ray）
+resource "aws_cloudwatch_log_delivery" "runtime_traces" {
+  delivery_source_name     = aws_cloudwatch_log_delivery_source.runtime_traces.name
+  delivery_destination_arn = aws_cloudwatch_log_delivery_destination.runtime_traces.arn
 }


### PR DESCRIPTION
## Summary

- AgentCore Runtimeのログ出力とトレース配信を有効化
- Memoryと同様のパターンでCloudWatch Logs/X-Rayへの配信を設定

## Changes

### `terraform/locals.tf`
- Runtime用ログ名を追加
  - `runtime_app_log_group_name`: APPLICATION_LOGS用
  - `runtime_usage_log_group_name`: USAGE_LOGS用

### `terraform/observability.tf`
- Runtime用Observability設定を追加（11リソース）

| 設定 | ログタイプ | 用途 |
|------|-----------|------|
| APPLICATION_LOGS | CloudWatch Logs | エージェントの標準出力・エラーログ |
| USAGE_LOGS | CloudWatch Logs | セッション単位のCPU/メモリ使用量 |
| TRACES | X-Ray | InvokeAgentRuntimeなどのスパンデータ |

## Test plan

- [x] `terraform validate` 成功
- [x] `terraform plan` で11リソースの作成を確認
- [ ] `terraform apply` でリソース作成
- [ ] CloudWatch GenAI Observabilityダッシュボードでメトリクス表示確認

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)