### PR TITLE
Issue #80対応: Lambda Pythonランタイムを3.13にアップグレード

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -19,7 +19,7 @@ variable "environment" {
 variable "lambda_runtime" {
   description = "Lambda関数のランタイムバージョン"
   type        = string
-  default     = "python3.12"
+  default     = "python3.13"
 }
 
 variable "lambda_timeout_seconds" {


### PR DESCRIPTION
## Summary
- Lambda関数のPythonランタイムを3.12から3.13にアップグレード
- `pyproject.toml`（`requires-python = ">=3.13"`）との一貫性を確保

## 変更内容
- `terraform/variables.tf`: `lambda_runtime`のデフォルト値を`python3.13`に変更

## Test plan
- [ ] `terraform plan`で変更内容を確認
- [ ] デプロイ後、Lambda関数が正常に動作することを確認
- [ ] S3トリガー経由でエージェント呼び出しが成功することを確認

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)