### PR TITLE
Issue #93対応: StrandsTelemetryの設定追加でObservabilityを有効化

### DIFF
--- a/app/server.py
+++ b/app/server.py
@@ -12,11 +12,25 @@ from typing import Any
 
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
+from strands.telemetry import StrandsTelemetry
 
 from .main import handler
 
 # ロギング設定はconfig.pyで一元管理されている
 logger = logging.getLogger(__name__)
+
+# ==============================================================================
+# OpenTelemetry設定
+# ==============================================================================
+# StrandsTelemetryを初期化してOTLPエクスポーターを設定
+# AgentCore Runtimeがテレメトリデータを収集し、CloudWatchに配信する
+try:
+    strands_telemetry = StrandsTelemetry()
+    strands_telemetry.setup_otlp_exporter()
+    logger.info("StrandsTelemetry initialized with OTLP exporter")
+except Exception as e:
+    # テレメトリ初期化に失敗してもサーバーは起動を続行
+    logger.warning(f"Failed to initialize StrandsTelemetry: {e}")
 
 # FastAPIアプリケーションの初期化
 app = FastAPI(title="AgentCore Runtime Server", description="Bedrock AgentCore Runtime用HTTPサーバー", version="1.0.0")


### PR DESCRIPTION
## Summary

- AgentCore RuntimeのログをCloudWatchに出力するため、StrandsTelemetryを初期化
- OTLPエクスポーターを設定してテレメトリデータをAgentCoreに送信

## 変更内容

- `app/server.py`: サーバー起動時にStrandsTelemetryを初期化し、OTLPエクスポーターを設定

## 動作確認

- 全97テストがパス
- デプロイ後、CloudWatch APPLICATION_LOGSにログが記録されることを確認

## Test plan

- [x] ユニットテスト（全97件パス）
- [x] 実環境デプロイ
- [x] CloudWatch APPLICATION_LOGSにログ出力を確認

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)