### PR TITLE
[Issue #105] OTLPエクスポート設定を削除してログノイズを解消

### DIFF
--- a/app/server.py
+++ b/app/server.py
@@ -22,12 +22,13 @@ logger = logging.getLogger(__name__)
 # ==============================================================================
 # OpenTelemetry設定
 # ==============================================================================
-# StrandsTelemetryを初期化してOTLPエクスポーターを設定
-# AgentCore Runtimeがテレメトリデータを収集し、CloudWatchに配信する
+# StrandsTelemetryを初期化
+# 注意: setup_otlp_exporter()は呼び出さない
+# AgentCore Runtime環境にはOTLPコレクターが存在しないため、
+# localhost:4318への接続エラーが発生する（Issue #105）
 try:
     strands_telemetry = StrandsTelemetry()
-    strands_telemetry.setup_otlp_exporter()
-    logger.info("StrandsTelemetry initialized with OTLP exporter")
+    logger.info("StrandsTelemetry initialized")
 except Exception as e:
     # テレメトリ初期化に失敗してもサーバーは起動を続行
     logger.warning(f"Failed to initialize StrandsTelemetry: {e}")


### PR DESCRIPTION
## Summary
- `setup_otlp_exporter()`呼び出しを削除
- AgentCore Runtime環境でのOTLPエクスポートエラーを解消

## 変更内容
AgentCore Runtime環境にはOTLPコレクター（localhost:4318）が存在しないため、
`StrandsTelemetry.setup_otlp_exporter()`呼び出しが毎回接続エラーを発生させていた。

```
ConnectionRefusedError: [Errno 111] Connection refused
urllib3.exceptions.NewConnectionError: HTTPConnection(host='localhost', port=4318)
```

この変更により：
- ログノイズが解消される（1分あたり約24回のエラーログ削減）
- アプリケーション機能には影響なし

## Test plan
- [x] 全テスト通過（97 passed）
- [ ] デプロイ後にログを確認してエラーが解消されていることを確認

Fixes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)