### PR TITLE
fix: HOMEディレクトリを/tmpに設定してstrands_toolsのPermissionErrorを解消

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@ ARG AGENTCORE_MEMORY_ID=""
 # 環境変数設定
 ENV AGENTCORE_MEMORY_ID=${AGENTCORE_MEMORY_ID}
 ENV LTM_ENABLED=true
+# strands_toolsがホームディレクトリにワークフロー用ディレクトリを作成するため、
+# 書き込み可能な/tmpをHOMEに設定
+ENV HOME=/tmp
 
 # 非rootユーザーを作成
 RUN groupadd --gid 1000 appuser && \


### PR DESCRIPTION
## Summary
- DockerfileにHOME=/tmpを追加
- strands_toolsがホームディレクトリにワークフロー用ディレクトリを作成する際のPermissionErrorを解消

## 原因
- appuserは`--no-create-home`で作成されているため`/home/appuser`が存在しない
- strands_toolsがHOME配下にディレクトリを作成しようとして失敗

## 修正
```dockerfile
ENV HOME=/tmp
```

## Test plan
- [x] デプロイ後の動作確認完了
- [x] PermissionErrorが解消されていることを確認
- [x] StrandsTelemetryが正常に初期化されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)