### PR TITLE
[Issue #107] Lambda: S3保存処理のデバッグログを追加

### DIFF
--- a/lambda/invoker.py
+++ b/lambda/invoker.py
@@ -98,6 +98,7 @@ def save_response_to_s3(
     Returns:
         保存先のS3 URIまたはNone（保存に失敗した場合）
     """
+    logger.info(f"save_response_to_s3 entered, OUTPUT_BUCKET={OUTPUT_BUCKET}")
     if not OUTPUT_BUCKET:
         logger.warning("OUTPUT_BUCKET is not set, skipping response save")
         return None
@@ -244,9 +245,11 @@ def process_s3_record(record: Dict[str, Any], context: Any) -> Dict[str, Any]:
             session_id=session_id,
             payload=input_payload
         )
+        logger.info(f"invoke_agent_runtime returned, response length: {len(response)}")
 
         # エージェント応答をS3に保存
         input_text = input_payload.get('input', {}).get('text', '')
+        logger.info(f"Calling save_response_to_s3: bucket={bucket_name}, key={object_key}")
         output_uri = save_response_to_s3(
             bucket_name=bucket_name,
             object_key=object_key,
@@ -311,6 +314,7 @@ def invoke_agent_runtime(
         complete_response = process_event_stream(event_stream)
 
         logger.info(f"Agent response: {complete_response[:500]}...")
+        logger.info("About to return from invoke_agent_runtime")
         return complete_response
 
     except ClientError as e:


### PR DESCRIPTION
## Summary
- Lambda関数（agentcore-invoker）でS3への出力ファイル保存が行われない問題を調査
- 処理フローを追跡するデバッグログを4箇所に追加
- デプロイ後、S3保存が正常に動作することを確認

## Changes
- `invoke_agent_runtime`: return直前のログ追加
- `process_s3_record`: invoke_agent_runtime戻り値受信後のログ追加
- `process_s3_record`: save_response_to_s3呼び出し直前のログ追加
- `save_response_to_s3`: 関数開始時のログ追加

## Root Cause Analysis
CloudWatchログ調査の結果、デバッグログ追加前は`Agent response:`ログの3ms後にLambdaが終了していた。デバッグログ追加後のデプロイで正常動作を確認。推定原因は**以前のデプロイでコードが正しく更新されていなかった**可能性。

## Test plan
- [x] `make test` - 97 tests passed
- [x] デプロイ後の動作確認 - S3保存成功
- [x] CloudWatchログでデバッグログ出力を確認

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)