### PR TITLE
[Issue #118] Lambdaタイムアウトを15分に延長

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -25,7 +25,7 @@ variable "lambda_runtime" {
 variable "lambda_timeout_seconds" {
   description = "Lambda関数のタイムアウト時間（秒）"
   type        = number
-  default     = 300
+  default     = 900
 }
 
 variable "lambda_memory_mb" {


### PR DESCRIPTION
## Summary
- Lambda invokerのタイムアウトを300秒（5分）から900秒（15分）に延長

## 背景
ワークフロー処理（S3ファイル要約→パターン分析→プロファイル生成）に5分以上かかるケースがあり、タイムアウトエラーが発生していた。

## Test plan
- [x] `terraform plan`で変更内容を確認
- [ ] デプロイしてワークフローが完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)