### PR TITLE
[Issue #121] SessionManagerを活用したメモリ管理の統合

### DIFF
--- a/app/memory.py
+++ b/app/memory.py
@@ -41,23 +41,30 @@ def create_retrieval_config() -> dict[str, Any] | None:
     """
     LTM用のRetrievalConfigを作成する。
 
-    LTM_ENABLEDがtrueの場合、過去のファイル要約を取得するための
-    RetrievalConfig設定を返す。
+    LTM_ENABLEDがtrueの場合、過去のファイル要約とActor状態を取得するための
+    RetrievalConfig設定を返す。複数のNamespaceを含む設定を返すことで、
+    SessionManagerを通じて自動的に過去情報が注入される。
 
     Returns:
-        LTM有効時: Namespace -> RetrievalConfig設定の辞書
+        LTM有効時: Namespace -> RetrievalConfig設定の辞書（複数Namespace対応）
         LTM無効時: None
     """
     if not LTM_ENABLED:
         return None
 
-    # 過去のファイル要約を取得するための設定
-    # RetrievalConfigの形式はSDKに依存するため、辞書形式で定義
+    # 複数Namespaceの設定を返す
+    # これによりSessionManagerが自動的に両方のNamespaceから情報を取得
     return {
+        # 過去のファイル要約を取得するための設定
         LTM_NAMESPACE: {
             "top_k": LTM_SUMMARY_TOP_K,
             "relevance_score": LTM_SUMMARY_SCORE,
-        }
+        },
+        # Actor状態（嗜好・傾向）を取得するための設定
+        ACTOR_STATE_NAMESPACE: {
+            "top_k": ACTOR_STATE_TOP_K,
+            "relevance_score": 0.5,  # Actor状態は広めに取得
+        },
     }
 
 

--- a/app/workflow.py
+++ b/app/workflow.py
@@ -3,21 +3,23 @@ Strands Agents workflowツールを使用したワークフロー管理。
 
 このモジュールは、S3ファイルの要約とユーザープロファイル生成のための
 ワークフローを定義・実行する機能を提供する。
+
+SessionManager統合により、会話履歴は自動的に永続化され、
+Memory Strategyによる自動処理（嗜好抽出・要約等）が有効になる。
 """
 
 import logging
 from typing import Any
 
 from strands import Agent
-from strands_tools import use_aws, workflow
+from strands_tools import use_aws
 
 from .config import MODEL_ID
+from .memory import create_memory
 from .prompts import load_prompt
 from .tools import (
     get_past_preferences,
     retrieve_memory_tool,
-    save_memory_tool,
-    save_to_memory_via_event,
 )
 
 logger = logging.getLogger(__name__)
@@ -33,6 +35,7 @@ def create_s3_summarize_workflow() -> dict[str, Any]:
         - tasks: タスク定義のリスト
     """
     # プロンプトファイルから読み込む（見つからない場合はデフォルト値を使用）
+    # SessionManager統合により、保存は自動的に行われる
     try:
         summarize_prompt = load_prompt("workflow/summarize")
     except FileNotFoundError:
@@ -40,7 +43,7 @@ def create_s3_summarize_workflow() -> dict[str, Any]:
         summarize_prompt = (
             "あなたはS3ファイルを読み取り、内容を要約するエージェントです。\n"
             "use_awsツールを使用してS3ファイルの内容を取得し、\n"
-            "その内容を要約してsave_memory_toolで保存してください。"
+            "その内容を要約してください。会話履歴は自動的に保存されます。"
         )
 
     try:
@@ -59,18 +62,20 @@ def create_s3_summarize_workflow() -> dict[str, Any]:
         logger.warning("workflow/profile.md not found, using default prompt")
         profile_prompt = (
             "あなたはユーザープロファイルを生成するエージェントです。\n"
-            "分析結果に基づいてユーザーの特性や傾向をまとめ、\n"
-            "save_memory_toolを使用してプロファイルを保存してください。"
+            "分析結果に基づいてユーザーの特性や傾向をまとめてください。\n"
+            "会話履歴は自動的に保存され、Memory Strategyにより嗜好が抽出されます。"
         )
 
+    # SessionManager統合後、save_memory_toolは不要
+    # 保存はSessionManagerが自動的に行い、Memory Strategyで嗜好抽出される
     return {
         "workflow_id": "s3_summarize",
         "tasks": [
             {
                 "task_id": "summarize_s3_file",
-                "description": "S3ファイルを読み取り、内容を要約してメモリに保存",
+                "description": "S3ファイルを読み取り、内容を要約",
                 "system_prompt": summarize_prompt,
-                "tools": ["use_aws", "save_memory_tool"],
+                "tools": ["use_aws"],  # SessionManagerが自動保存
                 "dependencies": [],
             },
             {
@@ -82,9 +87,9 @@ def create_s3_summarize_workflow() -> dict[str, Any]:
             },
             {
                 "task_id": "generate_profile",
-                "description": "ユーザー特性をまとめてプロファイルを生成し保存",
+                "description": "ユーザー特性をまとめてプロファイルを生成",
                 "system_prompt": profile_prompt,
-                "tools": ["save_memory_tool"],
+                "tools": [],  # SessionManagerが自動保存
                 "dependencies": ["analyze_patterns"],
             },
         ],
@@ -145,19 +150,23 @@ def run_workflow(s3_info: dict[str, str], actor_id: str, session_id: str, memory
 過去の嗜好データはありません（初回分析）。
 """
 
+    # SessionManagerを作成（会話履歴の自動永続化 + LTMからの情報自動取得）
+    session_manager = create_memory(memory_id, session_id, actor_id)
+
     # ワークフロー用エージェントを作成
-    # workflowツールと、各タスクで使用するツールを含める
-    # save_to_memory_via_eventを追加（Memory Strategy自動処理用）
+    # SessionManager統合により、保存系ツールは不要
+    # 会話履歴は自動的に永続化され、Memory Strategyにより嗜好抽出される
     agent = Agent(
         model=MODEL_ID,
         system_prompt="あなたはワークフローを管理するエージェントです。",
-        tools=[workflow, use_aws, save_memory_tool, retrieve_memory_tool, save_to_memory_via_event],
+        tools=[use_aws, retrieve_memory_tool, get_past_preferences],
+        session_manager=session_manager,  # SessionManagerを渡す
     )
 
     logger.info(f"Creating workflow: {workflow_def['workflow_id']}")
 
     # ワークフローを作成・実行
-    # agent経由でworkflowツールを使用
+    # SessionManagerにより会話は自動保存され、Memory Strategyで嗜好抽出
     prompt = f"""
 以下のワークフローを実行してください。
 
@@ -174,20 +183,14 @@ S3ファイル情報:
 
 ワークフロー手順:
 1. まず、use_awsツールでS3からファイルを読み取り、内容を要約してください
-2. 次に、save_memory_toolで要約をメモリに保存してください（namespace: /file-summaries/{actor_id}）
-3. retrieve_memory_toolで過去の要約を取得し、パターンを分析してください
-4. 上記の「ユーザーの過去の嗜好・傾向」を考慮して、ユーザープロファイルを生成してください
-5. save_memory_toolでプロファイルを保存してください（namespace: /actor-state/{actor_id}）
-6. **重要**: 最後に、save_to_memory_via_eventツールを以下のパラメータで呼び出してください:
-   - memory_id: {memory_id}
-   - session_id: {session_id}
-   - actor_id: {actor_id}
-   - user_content: ファイルの内容
-   - assistant_content: 分析結果・プロファイル
-   これにより、Memory Strategyによる自動嗜好抽出が有効になります。
+2. retrieve_memory_toolで過去の要約を取得し、パターンを分析してください
+3. 上記の「ユーザーの過去の嗜好・傾向」を考慮して、ユーザープロファイルを生成してください
 
 **重要**: 分析時は過去の嗜好を考慮し、より個別化された分析を行ってください。
 各ステップの結果を報告してください。
+
+注意: 会話履歴は自動的にメモリに保存され、Memory Strategyにより嗜好抽出が行われます。
+手動でsave_memory_toolを呼び出す必要はありません。
 """
 
     response = agent(prompt)

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -15,21 +15,30 @@ class TestCreateRetrievalConfig:
     def test_returns_config_when_ltm_enabled(self):
         """
         LTM有効時にRetrievalConfigが返されることを確認する。
+
+        SessionManager統合後、複数のNamespaceを含むRetrievalConfigが
+        返されることを検証する。
         """
         with (
             patch("app.memory.LTM_ENABLED", True),
             patch("app.memory.LTM_SUMMARY_TOP_K", 10),
             patch("app.memory.LTM_SUMMARY_SCORE", 0.3),
             patch("app.memory.LTM_NAMESPACE", "/file-summaries/{actorId}"),
+            patch("app.memory.ACTOR_STATE_NAMESPACE", "/actor-state/{actorId}"),
+            patch("app.memory.ACTOR_STATE_TOP_K", 5),
         ):
             from app.memory import create_retrieval_config
 
             result = create_retrieval_config()
 
             assert result is not None
+            # ファイル要約のNamespaceを含む
             assert "/file-summaries/{actorId}" in result
             assert result["/file-summaries/{actorId}"]["top_k"] == 10
             assert result["/file-summaries/{actorId}"]["relevance_score"] == 0.3
+            # Actor状態のNamespaceも含む
+            assert "/actor-state/{actorId}" in result
+            assert result["/actor-state/{actorId}"]["top_k"] == 5
 
     def test_returns_none_when_ltm_disabled(self):
         """

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -103,8 +103,8 @@ class TestCreateS3SummarizeWorkflow:
         """
         summarize_s3_fileタスクが正しいツールを持つことを確認。
 
-        summarize_s3_fileタスクは、use_awsとsave_memory_toolの
-        2つのツールを使用することを検証する。
+        SessionManager統合後、summarize_s3_fileタスクはuse_awsのみを使用する。
+        保存はSessionManagerによって自動的に行われる。
         """
         from app.workflow import create_s3_summarize_workflow
 
@@ -114,7 +114,8 @@ class TestCreateS3SummarizeWorkflow:
 
         # Assert
         assert "use_aws" in summarize_task["tools"]
-        assert "save_memory_tool" in summarize_task["tools"]
+        # SessionManager統合後、save_memory_toolは不要
+        assert "save_memory_tool" not in summarize_task["tools"]
 
     def test_task_analyze_patterns_has_retrieve_memory_tool(self):
         """
@@ -132,12 +133,12 @@ class TestCreateS3SummarizeWorkflow:
         # Assert
         assert "retrieve_memory_tool" in analyze_task["tools"]
 
-    def test_task_generate_profile_has_save_memory_tool(self):
+    def test_task_generate_profile_does_not_have_save_memory_tool(self):
         """
-        generate_profileタスクがsave_memory_toolを持つことを確認。
+        generate_profileタスクがsave_memory_toolを持たないことを確認。
 
-        generate_profileタスクは、ユーザープロファイルを保存するために
-        save_memory_toolを使用することを検証する。
+        SessionManager統合後、保存はSessionManagerによって自動的に行われるため、
+        save_memory_toolは不要であることを検証する。
         """
         from app.workflow import create_s3_summarize_workflow
 
@@ -146,7 +147,8 @@ class TestCreateS3SummarizeWorkflow:
         profile_task = next(task for task in workflow["tasks"] if task["task_id"] == "generate_profile")
 
         # Assert
-        assert "save_memory_tool" in profile_task["tools"]
+        # SessionManager統合後、save_memory_toolは不要
+        assert "save_memory_tool" not in profile_task["tools"]
 
     def test_all_tasks_have_descriptions(self):
         """
@@ -254,10 +256,16 @@ class TestRunWorkflow:
         actor_id = "test-actor"
         session_id = "test-session"
 
-        # Mock the Agent
-        with patch("app.workflow.Agent") as mock_agent_class:
+        # Mock the Agent and create_memory
+        with (
+            patch("app.workflow.Agent") as mock_agent_class,
+            patch("app.workflow.create_memory") as mock_create_memory,
+            patch("app.workflow.get_past_preferences") as mock_get_prefs,
+        ):
             mock_agent_instance = mock_agent_class.return_value
             mock_agent_instance.return_value = "Workflow completed successfully"
+            mock_create_memory.return_value = "mock-session-manager"
+            mock_get_prefs.return_value = ""
 
             # Act
             result = run_workflow(s3_info=s3_info, actor_id=actor_id, session_id=session_id, memory_id=memory_id)
@@ -335,10 +343,16 @@ class TestRunWorkflow:
         actor_id = "test-actor"
         session_id = "test-session"
 
-        # Mock Agent
-        with patch("app.workflow.Agent") as mock_agent_class:
+        # Mock Agent and create_memory
+        with (
+            patch("app.workflow.Agent") as mock_agent_class,
+            patch("app.workflow.create_memory") as mock_create_memory,
+            patch("app.workflow.get_past_preferences") as mock_get_prefs,
+        ):
             mock_agent_instance = mock_agent_class.return_value
             mock_agent_instance.return_value = "User profile: Technical user with data analysis focus"
+            mock_create_memory.return_value = "mock-session-manager"
+            mock_get_prefs.return_value = ""
 
             # Act
             result = run_workflow(s3_info=s3_info, actor_id=actor_id, session_id=session_id, memory_id=memory_id)
@@ -362,13 +376,15 @@ class TestRunWorkflow:
         actor_id = "user-456"
         session_id = "session-789"
 
-        # Mock Agent and get_past_preferences
+        # Mock Agent, create_memory and get_past_preferences
         with (
             patch("app.workflow.Agent") as mock_agent_class,
+            patch("app.workflow.create_memory") as mock_create_memory,
             patch("app.workflow.get_past_preferences") as mock_get_prefs,
         ):
             mock_agent_instance = mock_agent_class.return_value
             mock_agent_instance.return_value = "Workflow completed"
+            mock_create_memory.return_value = "mock-session-manager"
             mock_get_prefs.return_value = ""
 
             # Act
@@ -390,8 +406,8 @@ class TestRunWorkflow:
         """
         ワークフローがAgentを正しいツールで作成することを確認。
 
-        Agentにworkflow、use_aws、save_memory_tool、retrieve_memory_tool、
-        save_to_memory_via_eventが渡されることを検証する。
+        SessionManager統合後は、save_memory_tool、save_to_memory_via_eventは不要。
+        use_aws、retrieve_memory_tool、get_past_preferencesのみを使用する。
         """
         from app.workflow import run_workflow
 
@@ -401,13 +417,15 @@ class TestRunWorkflow:
         actor_id = "test-actor"
         session_id = "test-session"
 
-        # Mock Agent and get_past_preferences
+        # Mock Agent, create_memory, and get_past_preferences
         with (
             patch("app.workflow.Agent") as mock_agent_class,
+            patch("app.workflow.create_memory") as mock_create_memory,
             patch("app.workflow.get_past_preferences") as mock_get_prefs,
         ):
             mock_agent_instance = mock_agent_class.return_value
             mock_agent_instance.return_value = "Workflow completed"
+            mock_create_memory.return_value = "mock-session-manager"
             mock_get_prefs.return_value = ""
 
             # Act
@@ -420,8 +438,8 @@ class TestRunWorkflow:
             call_kwargs = mock_agent_class.call_args.kwargs
             assert "tools" in call_kwargs
             tools = call_kwargs["tools"]
-            # 5つのツールが渡されることを確認（save_to_memory_via_event追加）
-            assert len(tools) == 5
+            # SessionManager統合後は3つのツール（use_aws, retrieve_memory_tool, get_past_preferences）
+            assert len(tools) == 3
 
     def test_run_workflow_retrieves_past_preferences(self):
         """
@@ -438,13 +456,15 @@ class TestRunWorkflow:
         actor_id = "test-actor"
         session_id = "test-session"
 
-        # Mock Agent and get_past_preferences
+        # Mock Agent, create_memory and get_past_preferences
         with (
             patch("app.workflow.Agent") as mock_agent_class,
+            patch("app.workflow.create_memory") as mock_create_memory,
             patch("app.workflow.get_past_preferences") as mock_get_prefs,
         ):
             mock_agent_instance = mock_agent_class.return_value
             mock_agent_instance.return_value = "Workflow completed"
+            mock_create_memory.return_value = "mock-session-manager"
             mock_get_prefs.return_value = "ユーザーはPythonを好む傾向がある"
 
             # Act
@@ -477,10 +497,12 @@ class TestRunWorkflow:
 
         with (
             patch("app.workflow.Agent") as mock_agent_class,
+            patch("app.workflow.create_memory") as mock_create_memory,
             patch("app.workflow.get_past_preferences") as mock_get_prefs,
         ):
             mock_agent_instance = mock_agent_class.return_value
             mock_agent_instance.return_value = "Analysis complete"
+            mock_create_memory.return_value = "mock-session-manager"
             mock_get_prefs.return_value = past_prefs
 
             # Act
@@ -508,10 +530,12 @@ class TestRunWorkflow:
 
         with (
             patch("app.workflow.Agent") as mock_agent_class,
+            patch("app.workflow.create_memory") as mock_create_memory,
             patch("app.workflow.get_past_preferences") as mock_get_prefs,
         ):
             mock_agent_instance = mock_agent_class.return_value
             mock_agent_instance.return_value = "First analysis complete"
+            mock_create_memory.return_value = "mock-session-manager"
             mock_get_prefs.return_value = ""  # 嗜好データなし
 
             # Act
@@ -521,12 +545,12 @@ class TestRunWorkflow:
             assert result is not None
             mock_get_prefs.assert_called_once()
 
-    def test_run_workflow_uses_save_to_memory_via_event(self):
+    def test_run_workflow_uses_session_manager(self):
         """
-        ワークフローがsave_to_memory_via_eventを使用することを確認。
+        ワークフローがSessionManagerをAgentに渡すことを確認。
 
-        Memory Strategy自動処理を有効にするため、
-        save_to_memory_via_eventがツールとして含まれることを検証する。
+        SessionManagerにより会話履歴が自動永続化され、
+        Memory Strategyによる自動処理が有効になることを検証する。
         """
         from app.workflow import run_workflow
 
@@ -538,10 +562,49 @@ class TestRunWorkflow:
 
         with (
             patch("app.workflow.Agent") as mock_agent_class,
+            patch("app.workflow.create_memory") as mock_create_memory,
             patch("app.workflow.get_past_preferences") as mock_get_prefs,
         ):
             mock_agent_instance = mock_agent_class.return_value
             mock_agent_instance.return_value = "Workflow completed"
+            mock_session_manager = "mock-session-manager"
+            mock_create_memory.return_value = mock_session_manager
+            mock_get_prefs.return_value = ""
+
+            # Act
+            run_workflow(s3_info=s3_info, actor_id=actor_id, session_id=session_id, memory_id=memory_id)
+
+            # Assert
+            # create_memoryが正しいパラメータで呼ばれたことを確認
+            mock_create_memory.assert_called_once_with(memory_id, session_id, actor_id)
+            # Agentにsession_managerが渡されたことを確認
+            call_kwargs = mock_agent_class.call_args.kwargs
+            assert "session_manager" in call_kwargs
+            assert call_kwargs["session_manager"] == mock_session_manager
+
+    def test_run_workflow_does_not_use_save_tools(self):
+        """
+        ワークフローが保存系ツールを使用しないことを確認。
+
+        SessionManager統合後は、save_memory_tool、save_to_memory_via_eventは
+        不要であり、Agentのツールリストに含まれないことを検証する。
+        """
+        from app.workflow import run_workflow
+
+        # Arrange
+        s3_info = {"bucket": "test-bucket", "key": "test-file.txt"}
+        memory_id = "test-memory-id"
+        actor_id = "test-actor"
+        session_id = "test-session"
+
+        with (
+            patch("app.workflow.Agent") as mock_agent_class,
+            patch("app.workflow.create_memory") as mock_create_memory,
+            patch("app.workflow.get_past_preferences") as mock_get_prefs,
+        ):
+            mock_agent_instance = mock_agent_class.return_value
+            mock_agent_instance.return_value = "Workflow completed"
+            mock_create_memory.return_value = "mock-session-manager"
             mock_get_prefs.return_value = ""
 
             # Act
@@ -550,6 +613,7 @@ class TestRunWorkflow:
             # Assert
             call_kwargs = mock_agent_class.call_args.kwargs
             tools = call_kwargs.get("tools", [])
-            # save_to_memory_via_event関数が含まれることを確認
+            # 保存系ツールが含まれないことを確認
             tool_names = [getattr(t, "__name__", str(t)) for t in tools]
-            assert any("save_to_memory_via_event" in name for name in tool_names)
+            assert not any("save_memory_tool" in name for name in tool_names)
+            assert not any("save_to_memory_via_event" in name for name in tool_names)


### PR DESCRIPTION
## Summary

- SessionManagerをAgentに渡すようにworkflow.pyを修正
- 不要になった保存系ツール（save_memory_tool, save_to_memory_via_event）をワークフローから削除
- memory.pyのcreate_retrieval_config()を複数Namespace対応に拡張
- テストをSessionManager統合に対応

## 変更の背景

現状のコードでは、Strands AgentsのSessionManagerが適切に活用されておらず、短期メモリ（STM）と長期メモリ（LTM）の管理が手動のboto3 API呼び出しに依存していました。

SessionManagerを正しく統合することで以下の改善を実現：
- **コード量削減**: 手動保存ロジックが不要に
- **自動会話履歴**: SessionManagerによる透過的なSTM管理
- **LTM自動抽出**: Memory Strategyによるユーザー嗜好の自動学習
- **retrieval_configの活用**: エージェント応答時に過去情報が自動注入

## Test plan

- [x] 全テストがパスすることを確認（`make test`）
- [ ] 実環境でのデプロイと動作確認（`make deploy && make get-runtime-info`）
  - AWS認証が切れているため、後で確認が必要

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)